### PR TITLE
Fix inference CLI and add GitHub Action to test it

### DIFF
--- a/.github/workflows/test-inference-cli.yml
+++ b/.github/workflows/test-inference-cli.yml
@@ -51,10 +51,10 @@ jobs:
         "
                 echo "MY_DATA_FILE=/tmp/my_data_file.h5ad" >> $GITHUB_ENV
     - name: Test MLM+RDA inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling ++data_module.rda_transform=auto_align data_module.log_normalize_transform=false data_module.max_length=4096 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling ++data_module.rda_transform=auto_align data_module.log_normalize_transform=false data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1  task.accelerator=cpu
     - name: Test MLM+Multitask inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=4096 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.multitask.v1
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.multitask.v1 task.accelerator=cpu
     - name: Test WCED+Multitask inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 task.accelerator=cpu
     - name: Test WCED inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling checkpoint=ibm-research/biomed.rna.bert.110m.wced.v1
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.v1  task.accelerator=cpu

--- a/.github/workflows/test-inference-cli.yml
+++ b/.github/workflows/test-inference-cli.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Test inference CLI
 
 on:
   push:

--- a/.github/workflows/test-inference-cli.yml
+++ b/.github/workflows/test-inference-cli.yml
@@ -1,0 +1,60 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install the latest version of uv and set the python version
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install cURL Headers (for hic-straw install/build)
+      run: sudo apt-get install libcurl4-openssl-dev
+    - name: Install package
+      run: uv pip install -q .
+    - name: Print environment
+      run: uv pip freeze
+    - name: Cache Hugging Face Transformers / Datasets
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/huggingface
+        key: hf-cache-${{ runner.os }}-${{ matrix.python-version }}
+        restore-keys: hf-cache-${{ runner.os }}-
+    - name: Download and preprocess Scanpy sample file
+      run: |
+        python -c "
+        import scanpy as sc
+        import anndata as ad
+        import numpy as np
+
+        adata = sc.datasets.pbmc3k()
+        adata = adata[np.random.choice(adata.shape[0], 50, replace=False)]  # downsample to 50
+        adata.raw = adata  # store raw counts
+        adata.write_h5ad('/tmp/my_data_file.h5ad')
+        "
+                echo "MY_DATA_FILE=/tmp/my_data_file.h5ad" >> $GITHUB_ENV
+    - name: Test MLM+RDA inference
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling ++data_module.rda_transform=auto_align data_module.log_normalize_transform=false data_module.max_length=4096 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1
+    - name: Test MLM+Multitask inference
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=4096 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.multitask.v1
+    - name: Test WCED+Multitask inference
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1
+    - name: Test WCED inference
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling checkpoint=ibm-research/biomed.rna.bert.110m.wced.v1

--- a/.github/workflows/test-inference-cli.yml
+++ b/.github/workflows/test-inference-cli.yml
@@ -51,10 +51,10 @@ jobs:
         "
                 echo "MY_DATA_FILE=/tmp/my_data_file.h5ad" >> $GITHUB_ENV
     - name: Test MLM+RDA inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling ++data_module.rda_transform=auto_align data_module.log_normalize_transform=false data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1  task.accelerator=cpu
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling ++data_module.rda_transform=auto_align data_module.log_normalize_transform=false data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1  task.accelerator=cpu task.precision=32
     - name: Test MLM+Multitask inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.multitask.v1 task.accelerator=cpu
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.mlm.multitask.v1 task.accelerator=cpu task.precision=32
     - name: Test WCED+Multitask inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 task.accelerator=cpu
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 task.accelerator=cpu task.precision=32
     - name: Test WCED inference
-      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.v1  task.accelerator=cpu
+      run: bmfm-targets-run -cn predict input_file=$MY_DATA_FILE working_dir=/tmp data_module.collation_strategy=language_modeling data_module.max_length=256 checkpoint=ibm-research/biomed.rna.bert.110m.wced.v1 task.accelerator=cpu task.precision=32

--- a/bmfm_targets/config/model_config.py
+++ b/bmfm_targets/config/model_config.py
@@ -45,6 +45,7 @@ class SCModelConfigBase(PretrainedConfig):
 
     def __setstate__(self, state):
         state.setdefault("label_columns", None)
+        state.setdefault("_output_attentions", state.get("output_attentions", None))
         self.__dict__.update(state)
 
 

--- a/bmfm_targets/tasks/scbert/scbert_main.py
+++ b/bmfm_targets/tasks/scbert/scbert_main.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 from copy import deepcopy
 
 import hydra
@@ -54,10 +53,6 @@ def main(cfg: config.SCBertMainHydraConfigSchema) -> None:
             cfg_obj.data_module,
             cfg_obj.trainer,
             clearml_logger,
-        )
-
-        subprocess.run(
-            ["chmod", "-R", "g+rws", str(cfg_obj.task.default_root_dir)], check=False
         )
 
 


### PR DESCRIPTION
Following reports of inference failing due to `_output_attentions` not being found, I added a GitHub Action to test the recommended usage explicitly which reproduces the problem and also the fix for it.