### PR TITLE
Claude skill bmfm targets run

### DIFF
--- a/.claude/skills/bmfm-targets-run/SKILL.md
+++ b/.claude/skills/bmfm-targets-run/SKILL.md
@@ -20,24 +20,25 @@ Six task classes — all go through the same `bmfm-targets-run` entry point:
 5. **dna_finetune** (`-cn dna_finetune_train_and_test_config`) — DNA supervised fine-tuning
 6. **interpret** — Captum-based attribution using `InterpretTaskConfig` (see `references/interpret.md`)
 
-Out of scope for this skill: systematic benchmarking across datasets (`bmfm_targets/evaluation/benchmark_configs/`) and dataset conversion (h5ad→litdata, parquet→litdata). If the user asks for those, tell them the skill doesn't cover them and point at the relevant directories.
+Out of scope: `benchmark_configs/` and dataset conversion (h5ad→litdata, parquet→litdata). Point users at `bmfm_targets/evaluation/benchmark_configs/README.md` and `bmfm_targets/datasets/data_conversion/`.
 
 ## Environment detection
 
-Before doing anything else, figure out which environment you're in. This affects everything downstream.
+Before doing anything else, figure out which environment you're in.
 
 - **Check for `run/` in the current working directory.** If it exists, the user has the repo cloned. Use the repo's own configs as starting points and invoke with `-cd run -cn <config_name>`. Read `run/checkpoints/<ckpt>.yaml` directly for provenance.
 - **If `run/` doesn't exist**, the user pip-installed. Fall back to the skill's bundled templates in `examples/`. Invoke with `--config-dir <path-to-skill>/examples -cn <template_name>`. Don't pretend `run/` exists.
 - **Check for a virtualenv.** If the CWD has a `.venv/bin/bmfm-targets-run`, prefer that binary. Otherwise use whatever `bmfm-targets-run` resolves to on PATH.
+- **MPS (Apple Silicon) is fully supported** — use `task.accelerator=mps` for all models. BERT models work natively. LLaMA v2 models require the `flex_attention` CPU/MPS guard in `bmfm_targets/models/common/llama/llama_layers.py` (see feedback memory). On a single MPS device, **run predict jobs sequentially** — parallel jobs thrash shared GPU memory. Chain with `&&`.
 
 ## Core mental model
 
 The checkpoint is the frame. Everything else is overrides.
 
-1. **Identify the task class** (the six above) from what the user describes.
-2. **If the user names a checkpoint, read its provenance** — `run/checkpoints/<ckpt_id>.yaml` now exists for every published v1 and v2 checkpoint (llama included, as of April 2026). The provenance yaml tells you what data_module, fields, tokenizer, losses, and max_length the checkpoint was trained with. Don't hardcode its overrides — read them from the provenance. See `references/checkpoints.md` for a per-checkpoint summary of what's load-bearing.
-3. **Override only what the user's situation requires.** Paths and working_dir always. `max_length` if the user needs more or less context (the pretraining value is the ceiling, not a requirement). `rda_transform` if the user wants a different RDA policy. Losses if the downstream task demands something different from what the checkpoint was trained with (see `references/losses.md`).
-4. **Propose what the checkpoint used as the default loss.** Only reach for alternatives when the problem genuinely differs — e.g. user has a regression target (MSE), severe class imbalance (focal), hierarchical labels (HCE). Explain the reasoning when you deviate.
+1. **Identify the task class** from what the user describes.
+2. **If the user names a checkpoint, read its provenance** — `run/checkpoints/<ckpt_id>.yaml` exists for every published v1 and v2 checkpoint. The provenance yaml tells you what data_module, fields, tokenizer, losses, and max_length the checkpoint was trained with. Don't hardcode overrides — read them from provenance. See `references/checkpoints.md` for a per-checkpoint summary.
+3. **Override only what the user's situation requires.** Paths and working_dir always. `max_length` if needed. Losses if the downstream task differs from pretraining.
+4. **Propose what the checkpoint used as the default loss.** Only reach for alternatives when the problem genuinely differs — regression (MSE), imbalance (focal), hierarchical ontology labels (HCE). Explain the reasoning when you deviate.
 
 ## Workflow
 
@@ -45,110 +46,125 @@ Follow this sequence. Don't skip the inspection step — it's what separates thi
 
 ### 1. Understand the user's goal
 
-Pin down, in this order: **what task class** (predict / finetune / pretrain / dna_{predict,finetune} / interpret), **what data they have** (h5ad path / csv directory / existing checkpoint), **what checkpoint** (HuggingFace id or local path, if any), **what they want out** (embeddings, predictions, fine-tuned model, attribution maps). If any of these are ambiguous, ask — don't guess.
+Pin down task class, data path, checkpoint id, and desired output. Ask if any are ambiguous — don't guess.
 
 ### 2. Actively inspect the data
 
-This is the step users struggle to do themselves. Before you write any yaml:
+Before writing any yaml:
 
-- **For h5ad input**: read the file with `scanpy`, print `adata.shape`, `adata.obs.columns`, `adata.obs.dtypes`, and for each candidate label column print `nunique()` + head. Propose label column(s) to the user for confirmation.
-- **For a csv directory (DNA)**: read `train.csv` head + dtypes, identify which columns are the sequence and which are labels, and whether labels are float (regression) or categorical (classification).
-- **Check for a split column** (`split_random`, `split_stratified_<label>`, or a user-named one). If absent in h5ad, propose creating one (see `references/data_prep.md`).
+- **For h5ad input**: read with `scanpy`, print `adata.shape`, `adata.obs.columns`, `adata.obs.dtypes`, and for each candidate label column print `nunique()` + head. Propose label column(s) for confirmation.
+- **For a csv directory (DNA)**: read `train.csv` head + dtypes, identify sequence and label columns, check if labels are float (regression) or categorical.
+- **Check for a split column.** If absent in h5ad, propose creating one (see `references/data_prep.md`).
 
-See `references/data_prep.md` for the exact snippets to run. Always confirm inferences with the user before writing the yaml.
+Always confirm inferences with the user before writing the yaml.
 
 ### 3. Choose the output shape
 
-The skill produces one of two artifacts:
-
-- **CLI one-liner** — for `predict` and `dna_predict`. Small, stateless, matches the repo README style. Put all overrides inline as `key=value` or `++key=value`.
-- **Yaml file** — for `finetune`, `pretrain`, `dna_finetune`, and `interpret`. Enough knobs that a one-liner becomes unreadable, and the user will want to rerun it. Write it under `configs/` in the repo root (or user-specified path), use plain `.yaml`, and produce a matching CLI one-liner that runs it with `-cd <dir> -cn <name>` or `--config-dir <dir> --config-name <name>`.
+- **CLI one-liner** — for `predict` and `dna_predict`.
+- **Yaml file** — for `finetune`, `pretrain`, `dna_finetune`, and `interpret`. Write it under `configs/` and produce a matching one-liner with `-cd <dir> -cn <name>`.
 
 ### 4. Write the config
 
-- Start from the closest existing template: `run/<task_class>.yaml` for the overall shape; `run/checkpoints/<ckpt>.yaml` for everything the checkpoint requires. Don't re-derive fields that the checkpoint provenance already sets correctly.
-- **When `checkpoint=` is set, do NOT emit `tokenizer:`, `fields:`, or `model:` blocks in the user's yaml.** The framework loads all three from the checkpoint and whatever you put in the yaml is ignored (predict / interpret) or a footgun waiting to happen (finetune, where a mismatched field spec silently breaks head shapes). Read the provenance to *understand* what the checkpoint expects so you can set the right `data_module` overrides, but don't copy those blocks into the user's config. The only time these blocks should appear is when the user is pretraining from scratch (no `checkpoint=`) or deliberately extending the schema (rare).
-- **Label-name clash with pretrained heads.** A clash happens **if and only if** the user's `label_column_name` is *identical* to a name the checkpoint already has a head for (e.g. the v2 47m WCED has `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`, `sex`; the v1 BERT WCED multitask has `cell_type`, `tissue`, `donor_id`). When names match, Lightning tries to load pretrained head weights into the user's fresh head: if `n_unique_values` matches the pretrained head it loads silently with the wrong label-index meaning, and if it doesn't it fails with a shape mismatch. When the names differ, a fresh head is added and there is nothing to worry about. Rule: check the checkpoint's provenance yaml; if the user's column matches a name there, rename it (e.g. `cell_type` → `my_cell_type`); otherwise move on.
-- **At predict/test time**, `label_columns` works differently: the checkpoint's label_columns is authoritative and the YAML's is ignored (with a warning). Pass an explicit empty list (`label_columns: []`) to get embedding-only mode. Don't try to "use a different label column" at predict time; finetune first or run embedding-only.
-- Use `++` for fields that might not exist in the base config (the Hydra "add or override" operator). Use plain `key=value` for fields that definitely exist. Getting this wrong is a common Hydra error — see `references/overrides.md`.
-- For losses: read the user's problem type and the checkpoint's own losses, then propose. See `references/losses.md`.
-- For custom pretraining field/loss/tokenizer triples: see `references/fields_tokenizer.md`. This is deep lore; most users shouldn't need it.
-- **Split strategy matters more than people think.** Large pretrained RNA models learn donor / batch structure; a random split at finetune is too easy and generalization numbers will flatter the model. If the user has a `donor_id` or `batch` / `assay` / `dataset_id` column with ≥4 distinct values, propose a held-out-donor split (or held-out-batch) over `split_random`. If the grouping column has only 2–3 values it's not really splittable — note that to the user rather than pretending otherwise. See `references/data_prep.md` for snippets.
-- **Pooling method for inference and finetune heads.** The `pooling_method` knob on `trainer` controls how the sequence is reduced to a vector for downstream heads. Options: `"first_token"` (default, always valid), `"pooling_layer"` (only valid when the pooler was trained — i.e. sequence-classification or multitask checkpoints, NOT pure MLM), `"mean_pooling"`, an integer CLS index (e.g. `1`, `2` for the v2 47m's per-task CLS tokens), or a list like `[1, 2]` to concat multiple CLS tokens (e.g. S+T for CellXGene-style representations). For RDA-style `predict`, `first_token` (or `0`) is usually right. For finetuning off a multi-CLS v2 checkpoint, either pick the `decode_from` that matches the pretrained head closest to your task, or fall back to `first_token`. See `references/overrides.md`.
+- Start from the closest template: `run/<task_class>.yaml` for shape; `run/checkpoints/<ckpt>.yaml` for what the checkpoint requires.
+- **When `checkpoint=` is set, do NOT emit `tokenizer:`, `fields:`, or `model:` blocks.** The framework loads all three from the checkpoint. Read provenance to understand what the checkpoint expects so you can set the right `data_module` overrides, but don't copy those blocks into the user's config.
+- **Label-name clash with pretrained heads.** A clash happens **if and only if** the user's `label_column_name` is identical to a name the checkpoint already has a head for (v2 47m WCED: `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`, `sex`; v1 BERT WCED multitask: `cell_type`, `tissue`, `donor_id`). Mismatched shapes fail loudly; matched shapes load silently with wrong label-index meaning. When names differ, a fresh head is added — nothing to worry about. Rule: check provenance; if the user's column matches a name there, rename it.
+- **At predict/test time**, `label_columns` in the YAML is ignored (the checkpoint's is authoritative). Pass `label_columns: []` for embedding-only mode.
+- Use `++` for fields that might not exist in the base config. Use plain `key=value` for fields that definitely exist. **Exception: `++trainer.pooling_method=<value>` is a known footgun** — Hydra creates `self.trainer` as a bare dict rather than a `TrainerConfig` dataclass, which then crashes at `.merge_from_checkpoint()` with `AttributeError: 'dict' object has no attribute 'merge_from_checkpoint'`. The fix is in `bmfm_targets/config/main_config.py` (~line 354); if you see this error and the fix is absent, add an `isinstance(self.trainer, dict)` guard there.
+- **Split strategy matters.** Large pretrained RNA models learn donor / batch structure; a random split at finetune is too easy. If the user has `donor_id` / `batch` / `dataset_id` with ≥4 distinct values, propose a held-out-donor split. See `references/data_prep.md`.
+- **Pooling method — always choose explicitly, never rely on checkpoint defaults.** See section below.
 
 ### 5. Dry-run validate (always)
 
-Before telling the user "run this", invoke the Level-1 validator:
-
 ```bash
-bash .claude/skills/bmfm-targets-run/scripts/dry_run.sh <args you were going to give the user>
+bash .claude/skills/bmfm-targets-run/scripts/dry_run.sh <args>
 ```
 
-It wraps `bmfm-targets-run ... --cfg job --resolve` to render the fully-resolved config without starting training. If it errors, fix the config before handing it over. If the user explicitly asks for a smoke test (Level 2), add `task.max_epochs=1 ++task.max_steps=5 data_module.num_workers=0 task.accelerator=cpu task.precision=32` to actually run a few steps.
+Renders the fully-resolved config without starting training. Fix errors before handing off. For a smoke test (Level 2), add `task.max_epochs=1 ++task.max_steps=5 data_module.num_workers=0 task.accelerator=cpu task.precision=32`.
 
 ### 6. Hand off
 
-Give the user: the config file path (if any), the exact command line, a one-sentence note on what the command will produce and where, and any follow-up they'll likely want (e.g. `label_dict.json` will appear in `working_dir/`).
+Config file path (if any), exact command line, one sentence on what it produces and where, likely follow-up (e.g. `label_dict.json` in `working_dir/`).
 
-## Default loss selection (short version)
+## Pooling method
 
-The long version is in `references/losses.md`. The short version:
+**The pooling choice is a biological question, not just a model property.** Each CLS token in a multitask checkpoint encodes a different biological axis. A task-specific CLS (e.g. LLaMA-47m `CLS[1]`, trained for cell-type classification) concentrates cell-type signal and suppresses everything else — disease state, batch effects, developmental gradients. If you pool from `CLS[1]` and AD vs. control separation disappears, that's the intended tradeoff, not a bug. **Match the CLS to the downstream biological question, not to whatever gives the best cell-type ARI.**
 
-- **Classification (multi-class)**: `cross_entropy`. Switch to `focal` (γ=2) if classes are imbalanced.
-- **Binary classification**: `cross_entropy` with 2 classes is usually fine; `bce_with_logits` if the label is inherently binary float.
-- **Regression**: `mse`. Set `ignore_zero: true` if you're predicting expression-like values where most cells have zero.
+Always emit `++trainer.pooling_method=<choice>` explicitly. Never omit it; never rely on the stored checkpoint default (it reflects pretraining setup, not inference intent).
+
+Options:
+- `"first_token"` — raw CLS at position 0. Safe fallback for any checkpoint.
+- `"pooling_layer"` — CLS → Linear → tanh. **Only valid when this head was trained** (multitask checkpoints). Using it on an untrained pooler produces garbage silently.
+- `"mean_pooling"` — mean over non-padding positions. Rarely used in published recipes.
+- integer (e.g. `1`) — hidden state at a specific CLS index, matching the `decode_from` routing the checkpoint was trained with.
+- list of ints (e.g. `[1, 2]`) — concatenation of multiple CLS positions.
+
+Per-checkpoint choices (full table in `references/checkpoints.md`):
+
+| Checkpoint | Use |
+|---|---|
+| `bert.110m.mlm.rda.v1` | `first_token` — pooler untrained |
+| `bert.110m.mlm.multitask.v1` | `pooling_layer` — pooler trained |
+| `bert.110m.wced.v1` | `first_token` — pooler untrained |
+| `bert.110m.wced.multitask.v1` | `first_token` — avoids Linear projection; use `pooling_layer` only if you want the projected representation |
+| `llama.32m.mlm.multitask.v1` | `pooling_layer` — single CLS, pooler trained |
+| `llama.47m.wced.multitask.v1` | `1` (cell type), `2` (tissue), `[1,2]` (combined), `first_token` as last resort |
+
+## Default loss selection
+
+Full details in `references/losses.md`. Quick guide:
+
+- **Multi-class classification**: `cross_entropy`. Use `focal` (γ=2) for imbalanced classes.
+- **Binary classification**: `cross_entropy` with 2 classes; `bce_with_logits` for inherently binary float labels.
+- **Regression**: `mse`. Set `ignore_zero: true` for expression-like values.
 - **Multi-label (K independent binary targets)**: `bce_with_logits`.
-- **Cell Ontology cell type labels specifically**: `hce` (hierarchical cross-entropy). See the HCE section below — in practice this only applies to `cell_type_ontology_term_id` from CellXGene. For any other ontology-backed label you do **not** have the ontology wired in and must fall back to `cross_entropy` or `focal`.
-- **Multitask fine-tuning mirroring the checkpoint**: copy the checkpoint's loss block verbatim, then adapt the `label_column_name`s.
-- **Adversarial de-biasing (e.g. remove donor effects)**: set `gradient_reversal_coefficient` on the unwanted label's `LabelColumnInfo`; add a matching entry to `trainer.losses`. The v1 BERT WCED multitask checkpoint (coef 3.0, donor_id) and the v2 32m Llama MLM multitask (coef 1.0, donor_id) are the canonical references. Note: the v2 47m WCED llama does **not** use GRL — check the specific checkpoint's provenance.
-- **WCED**: requires BOTH `WCEDMasker` as the data_module's masking_strategy AND losses with `field_name: expressions` + `wced_target:`. The `wced_target` value is the user's choice: `input_genes`, `non_input_genes`, or `all_genes` — each is a different reconstruction objective. See `references/fields_tokenizer.md`.
-- **Any label loss requires a matching `LabelColumnInfo`** in `label_columns`. The loss binds an objective; the `LabelColumnInfo` defines the head shape (regression vs classification, n_classes, decode_from, GRL coef). Without the label_columns entry, instantiation fails.
+- **`cell_type_ontology_term_id` from CellXGene specifically**: `hce` (hierarchical cross-entropy, `label_ontology: celltypeont`). This is the **only** label for which `hce` is valid today — for any other cell-type column, use `cross_entropy`.
+- **Adversarial de-biasing, WCED, multitask**: see `references/losses.md`.
+- **Any label loss requires a matching `LabelColumnInfo`** in `label_columns`. Without it, instantiation fails.
 
 When you deviate from the checkpoint's defaults, explain why in one line.
 
-## HCE is narrower than it looks
+## Input data units
 
-HCE (Hierarchical Cross-Entropy) requires a registered ontology with roll-up edges so the objective can charge partial credit for predicting an ancestor of the correct term. In the current codebase the only ontology wired in is `celltypeont` (Cell Ontology), used exclusively for the `cell_type_ontology_term_id` column from CellXGene. That's the only label for which `hce` is a real option today.
+Every published RNA checkpoint was pretrained on **raw integer counts** normalized internally to CPM10k + log1p. Raw counts is the expected input. If the user's h5ad is already log-normalized:
+- Fine-tuning on a classification head: usually works (off-distribution but converges).
+- `predict` embeddings: may be usable if prior normalization was close to CPM10k+log1p.
+- Reconstruction / WCED / MLM heads: do **not** proceed — decoder output distributions won't match.
+- RDA checkpoints: refuse entirely — RDA operates at count level and will produce garbage on log-normalized input.
 
-Practical rules:
-
-- If the user is fine-tuning on CellXGene `cell_type_ontology_term_id` (the pretraining label for the v2 multitask checkpoints), `hce` is the natural match and lets the pretrained head init transfer cleanly. Set `label_ontology: celltypeont` on the `LabelColumnInfo`.
-- For any other label — including "cell type" columns with non-Cell-Ontology terms, or cell-type annotations the user made themselves — `hce` is not available. Use `cross_entropy` (or `focal` if imbalanced). Don't pretend otherwise; `hce` without a matching registered ontology will fail at instantiation.
-- If the user genuinely has a hierarchical label backed by a different ontology, registering it is out of scope for this skill — point them at `bmfm_targets/training/losses/objectives/hce.py` and the ontology loading code.
-
-## A note on input data units
-
-Every published RNA checkpoint was pretrained on **raw integer counts** that were then normalized internally (either by `log_normalize_transform` at CPM10k+log1p, or by an RDA mode that does its own log-normalization). Raw counts is the expected input for any downstream use. If the user's h5ad is already log-normalized, they can usually still fine-tune on a classification head (off-distribution but it converges), and maybe get usable embeddings via `predict`, but they should NOT run reconstruction / WCED / MLM / zero-shot prediction heads — the output distributions won't match. Ask them to re-obtain raw counts, or pick a different checkpoint. For RDA checkpoints specifically, refuse to proceed on log-normalized input — RDA operates on count-level values and will produce garbage. See `references/checkpoints.md` for the full policy.
+See `references/checkpoints.md` for the full policy.
 
 ## Working directory and artifact policy
 
-- If the user provides `working_dir`, use it.
-- Otherwise default to `./outputs/<task_class>_<YYYYMMDD-HHMMSS>/` in the current repo, and tell the user where you're putting it.
-- `/tmp` is acceptable for one-off `predict` runs where the artifacts are disposable, but default to a persistent dir otherwise.
-- `predict` produces `embeddings.csv` and `predictions.csv` in `working_dir/`; `finetune` produces `labels.json` plus the usual Lightning checkpoints; `interpret` produces attribution maps.
+- Use the user's `working_dir` if provided; otherwise default to `./outputs/<task_class>_<YYYYMMDD-HHMMSS>/`.
+- `/tmp` is acceptable for disposable `predict` runs; prefer a persistent dir otherwise.
+- `predict` produces `embeddings.csv` and `predictions.csv`; `finetune` produces `labels.json` + Lightning checkpoints; `interpret` produces attribution maps.
+- **Disk space warning for `predict`.** On a large h5ad (10k+ cells), `predictions.csv` (logits + probabilities) can reach 2–3 GB per checkpoint. Warn the user to check available space (`df -h .`) before running. If only embeddings are needed, delete `predictions.csv` after each run — `embeddings.csv` is typically <100 MB. Note: `task.output_predictions=false` does **not** suppress logit output in the current codebase; manual deletion is the only workaround.
+
+## Multi-checkpoint embedding comparison
+
+When comparing embeddings across several checkpoints on the same h5ad:
+
+1. **Use a named `working_dir` per checkpoint** (not timestamped). E.g. `working_dir=/tmp/bmfm_bert_first_token/`. Makes downstream loading deterministic.
+2. **Run sequentially on MPS/CPU.** Chain with `&&`.
+3. **Record the pooling method** in the dir name or a README. Silent defaults produce results that are uninterpretable later.
+4. After all runs: load `embeddings.csv` from each dir, concatenate with a `method` column, compute shared metrics.
 
 ## Debugging existing yaml
 
-When the user pastes a failing config:
-
-1. Read the full Hydra error. The first stack line tells you where instantiation failed; the second tells you which field. `Error instantiating 'bmfm_targets.config.TrainerConfig': missing 1 required positional argument: losses` means `trainer.losses` is absent or empty.
-2. Run the dry-run script on their config before proposing fixes — it'll surface all resolution errors, not just the first.
-3. Common failures: `_partial_` missing on a data_module that takes kwargs later, `${oc.env:...}` referencing an unset env var, `++` needed because the field isn't in the base schema, `-cd run` forgotten so Hydra can't find the named config.
+1. Read the full Hydra error. The first stack frame says where instantiation failed; the second says which field.
+2. Run the dry-run script before proposing fixes — it surfaces all resolution errors, not just the first.
+3. Common failures: `_partial_` missing on a data_module; `${oc.env:...}` referencing an unset var; `++` needed for a field not in the base schema; `-cd run` forgotten.
+4. **`AttributeError: 'dict' object has no attribute 'merge_from_checkpoint'`** — caused by `++trainer.pooling_method=<value>` creating `self.trainer` as a bare dict. Fix is in `bmfm_targets/config/main_config.py` (~line 354): add an `isinstance(self.trainer, dict)` guard that merges dict overrides onto the checkpoint-loaded `TrainerConfig` before calling `.merge_from_checkpoint()`.
 
 See `references/overrides.md` for the full gotcha list.
 
 ## When to go deep
 
-Don't read every reference file every time. Load on demand:
+Load on demand:
 
-- `references/checkpoints.md` — **before writing any config that names a checkpoint.** Has the v1 + v2 roster and how to infer overrides from provenance.
-- `references/losses.md` — when the user's problem type isn't obviously covered by the checkpoint's losses.
-- `references/overrides.md` — when a yaml fails with a Hydra error, or when the user asks about `++` vs `.` vs defaults-list override semantics.
-- `references/data_prep.md` — when the user has an h5ad / csv that isn't split-ready, or when you need to inspect what label columns exist.
+- `references/checkpoints.md` — before writing any config that names a checkpoint.
+- `references/losses.md` — for adversarial de-biasing, WCED, multitask, or anything not in the quick guide above.
+- `references/overrides.md` — when a yaml fails with a Hydra error.
+- `references/data_prep.md` — when the h5ad isn't split-ready or you need to inspect label columns.
 - `references/interpret.md` — for any interpret task.
-- `references/fields_tokenizer.md` — for custom pretraining: new tokenizer vocabs, new field/loss combinations, scale_adapt vs mlp_with_special_token_embedding, `decode_modes`.
-
-## Known limits
-
-- The skill does not currently cover `benchmark_configs/` or dataset conversion utilities (`h5ad2litdata`, `parquet2litdata`). Users asking for those should be pointed at `bmfm_targets/evaluation/benchmark_configs/README.md` and `bmfm_targets/datasets/data_conversion/`.
-- The skill assumes the current working directory is the repo root (or a subdirectory of it) when `run/` is present. If the user is elsewhere, tell them to `cd` or pass `--config-dir <abs path to run/>`.
+- `references/fields_tokenizer.md` — for custom pretraining: new vocabs, new field/loss combinations, `decode_modes`.

--- a/.claude/skills/bmfm-targets-run/SKILL.md
+++ b/.claude/skills/bmfm-targets-run/SKILL.md
@@ -22,6 +22,12 @@ Six task classes — all go through the same `bmfm-targets-run` entry point:
 
 Out of scope: `benchmark_configs/` and dataset conversion (h5ad→litdata, parquet→litdata). Point users at `bmfm_targets/evaluation/benchmark_configs/README.md` and `bmfm_targets/datasets/data_conversion/`.
 
+## Python API shortcut: `bmfm.inference`
+
+For in-notebook predict on a single checkpoint, skip Hydra and use `bmfm_targets.inference(adata, checkpoint=...)` — wraps the same `PredictTaskConfig` path and writes results back in place as `adata.obsm["X_bmfm"]` + `adata.obs["bmfm_pred_<label>"]`. Key kwargs: `layer`, `pooling_method`, `batch_size`, `max_length`, `limit_genes`, `device="auto"`, `log_normalize_transform`.
+
+Prefer it when: one checkpoint, no callbacks, results wanted on the `AnnData`. Fall back to `-cn predict` when you need eval callbacks, CSV artifacts, or anything beyond predict. Pooling / input-data / label-clash rules all apply unchanged (same underlying module).
+
 ## Environment detection
 
 Before doing anything else, figure out which environment you're in.
@@ -148,6 +154,28 @@ When comparing embeddings across several checkpoints on the same h5ad:
 2. **Run sequentially on MPS/CPU.** Chain with `&&`.
 3. **Record the pooling method** in the dir name or a README. Silent defaults produce results that are uninterpretable later.
 4. After all runs: load `embeddings.csv` from each dir, concatenate with a `method` column, compute shared metrics.
+
+## Callbacks
+
+Callbacks live in `bmfm_targets/training/callbacks.py` and are wired into a config under `task.callbacks:` as a list of `_target_: bmfm_targets.training.callbacks.<ClassName>` entries. The reference pattern is `bmfm_targets/evaluation/benchmark_configs/task/predict.yaml`, which stacks three evaluation callbacks on a `predict` run to produce embeddings + downstream metrics in one shot.
+
+Evaluation callbacks (fire on `on_predict_end`, require `task.output_embeddings: true`, and report to ClearML if a logger is active — otherwise they no-op with a warning):
+
+- **`BatchIntegrationCallback`** — scIB metrics (NMI, ARI, ASW, graph_conn) + UMAP plot colored by target / batch / counts + `scib_metrics` benchmarker table comparing the model's embedding to any baseline embeddings found in `adata.obsm`. Single-batch datasets fall back to a sklearn-based metrics path. Args: `batch_column_name`, `counts_column_name`, `target_column_name`.
+- **`CziBenchmarkCallback`** — czbenchmarks `MetadataLabelPredictionTask` with logistic regression over `n_folds` CV folds; reports `f1` as a scalar. Args: `batch_column_name`, `target_column_name`, `n_folds` (default 5).
+- **`SGDCallback`** — `SGDClassifier` trained on the predefined `train`+`dev` splits and evaluated on `test`, with 95% CIs (binomial or Wilson). Reports `SGD_f1` scalar. Requires a split column in `adata.obs`. Args: `batch_column_name`, `target_column_name`, `split_column_name` (default `"split"`), `obsm_key` (default `BMFM_RNA`), `ci_method` (`"binomial"` | `"wilson"`).
+
+All three read embeddings from `adata.obsm["BMFM_RNA"]` via `get_adata_with_embeddings(trainer, ...)`, which aligns prediction-loop outputs back to the datamodule's `predict_dataset.processed_data`. If the user's target column isn't set, the callback defaults to `trainer.datamodule.label_columns[0].label_column_name`.
+
+Training-time callbacks (use in `finetune` / pretrain configs):
+
+- **`BatchSizeScheduler`** — change `max_length` / `batch_size` per epoch. Supply `schedule: [{max_length, batch_size, n_epochs}, ...]`; optional `test_batch_size` / `test_max_length` override for the test stage. Total `n_epochs` must match `trainer.max_epochs` when any entry sets `n_epochs > 1`.
+- **`SavePretrainedModelCallback`** — periodically dump HF-format weights via `pl_module.save_transformer`. Args: `save_dir`, `tokenizer`, `epoch_period` (default 1), `step_period`.
+- **`InitialCheckpoint`** — saves an `initial.ckpt` at `on_train_start` so you can diff pretrained vs. fine-tuned.
+- **`SampleLevelLossCallback`** — on `on_test_end`, writes per-sample MSE / is-zero BCE to `sample_level_loss.csv`. Requires `trainer.batch_prediction_behavior` in `{"track", "dump"}` and the `metric_key` (default `"expressions_non_input_genes"`) to exist in `pl_module.prediction_df`.
+- **`SavePredictionsH5ADCallback`** — perturbation-specific: assembles predicted expressions into an h5ad at `trainer.log_dir/predictions.h5ad`, optionally concatenating non-targeting controls from a `train_h5ad_file`. Args include `perturbation_column_name`, `control_name`, `predictions_key`.
+
+When proposing callbacks, write them under `task.callbacks` and keep the arg names in sync with the datamodule's column names — benchmark_configs does this with OmegaConf refs like `target_column_name: ${data_module.label_column_name}`, which is the pattern to copy.
 
 ## Debugging existing yaml
 

--- a/.claude/skills/bmfm-targets-run/SKILL.md
+++ b/.claude/skills/bmfm-targets-run/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: bmfm-targets-run
+description: Generate, modify, debug, and run YAML configs and `bmfm-targets-run` CLI commands for the biomed-multi-omic (BMFM) package — scRNA (bmfm-rna) and DNA (bmfm-dna) foundation models. Use this skill whenever the user is working in the BiomedSciAI/biomed-multi-omic repo, mentions `bmfm-targets-run`, wants to run prediction / fine-tuning / pretraining / interpretation with BMFM checkpoints (e.g. `ibm-research/biomed.rna.bert.*`, `ibm-research/biomed.rna.llama.*`, `ibm-research/biomed.dna.modernbert.*`), asks about Hydra configs under `run/`, needs to translate a published checkpoint config into a fine-tuning config, picks a loss for a new downstream task, or is debugging a failing Hydra/yaml config in this codebase. Trigger even if the user doesn't say "yaml" or "config" — e.g. "I have an h5ad and I want embeddings" or "help me finetune on celltype" are core use cases for this skill.
+---
+
+# bmfm-targets-run
+
+The biomed-multi-omic package is enormously flexible — it's a single Hydra-configured training loop that handles RNA + DNA foundation models across pretraining, fine-tuning, prediction, and interpretability. That flexibility is also why new users get stuck: the yaml surface is large, and which knobs matter depends on which checkpoint you're starting from and what problem you're solving.
+
+This skill's job is to help the user move from **"I have data and a goal"** to **"a working command / yaml that does what I intended, with the right loss for my problem and the right overrides for my checkpoint"** — without drowning them in config. It does that by reading the checkpoint's provenance (the yaml it was trained from) rather than prescribing a recipe, by actively inspecting the user's data before picking labels or losses, and by always ending with a dry-run.
+
+## Scope
+
+Six task classes — all go through the same `bmfm-targets-run` entry point:
+
+1. **predict** (`-cn predict`) — zero-shot embeddings + label predictions from a BMFM checkpoint on an h5ad
+2. **finetune** (`-cn finetune`) — supervised RNA fine-tuning on a label column
+3. **pretrain** (`-cn mlm_train_config` / `-cn rda_mlm` / `-cn multitask_train_config`) — MLM / RDA / WCED / multitask pretraining
+4. **dna_predict** (`-cn dna_predict`) — DNA embeddings from a csv of sequences
+5. **dna_finetune** (`-cn dna_finetune_train_and_test_config`) — DNA supervised fine-tuning
+6. **interpret** — Captum-based attribution using `InterpretTaskConfig` (see `references/interpret.md`)
+
+Out of scope for this skill: systematic benchmarking across datasets (`bmfm_targets/evaluation/benchmark_configs/`) and dataset conversion (h5ad→litdata, parquet→litdata). If the user asks for those, tell them the skill doesn't cover them and point at the relevant directories.
+
+## Environment detection
+
+Before doing anything else, figure out which environment you're in. This affects everything downstream.
+
+- **Check for `run/` in the current working directory.** If it exists, the user has the repo cloned. Use the repo's own configs as starting points and invoke with `-cd run -cn <config_name>`. Read `run/checkpoints/<ckpt>.yaml` directly for provenance.
+- **If `run/` doesn't exist**, the user pip-installed. Fall back to the skill's bundled templates in `examples/`. Invoke with `--config-dir <path-to-skill>/examples -cn <template_name>`. Don't pretend `run/` exists.
+- **Check for a virtualenv.** If the CWD has a `.venv/bin/bmfm-targets-run`, prefer that binary. Otherwise use whatever `bmfm-targets-run` resolves to on PATH.
+
+## Core mental model
+
+The checkpoint is the frame. Everything else is overrides.
+
+1. **Identify the task class** (the six above) from what the user describes.
+2. **If the user names a checkpoint, read its provenance** — `run/checkpoints/<ckpt_id>.yaml` now exists for every published v1 and v2 checkpoint (llama included, as of April 2026). The provenance yaml tells you what data_module, fields, tokenizer, losses, and max_length the checkpoint was trained with. Don't hardcode its overrides — read them from the provenance. See `references/checkpoints.md` for a per-checkpoint summary of what's load-bearing.
+3. **Override only what the user's situation requires.** Paths and working_dir always. `max_length` if the user needs more or less context (the pretraining value is the ceiling, not a requirement). `rda_transform` if the user wants a different RDA policy. Losses if the downstream task demands something different from what the checkpoint was trained with (see `references/losses.md`).
+4. **Propose what the checkpoint used as the default loss.** Only reach for alternatives when the problem genuinely differs — e.g. user has a regression target (MSE), severe class imbalance (focal), hierarchical labels (HCE). Explain the reasoning when you deviate.
+
+## Workflow
+
+Follow this sequence. Don't skip the inspection step — it's what separates this skill from a recipe book.
+
+### 1. Understand the user's goal
+
+Pin down, in this order: **what task class** (predict / finetune / pretrain / dna_{predict,finetune} / interpret), **what data they have** (h5ad path / csv directory / existing checkpoint), **what checkpoint** (HuggingFace id or local path, if any), **what they want out** (embeddings, predictions, fine-tuned model, attribution maps). If any of these are ambiguous, ask — don't guess.
+
+### 2. Actively inspect the data
+
+This is the step users struggle to do themselves. Before you write any yaml:
+
+- **For h5ad input**: read the file with `scanpy`, print `adata.shape`, `adata.obs.columns`, `adata.obs.dtypes`, and for each candidate label column print `nunique()` + head. Propose label column(s) to the user for confirmation.
+- **For a csv directory (DNA)**: read `train.csv` head + dtypes, identify which columns are the sequence and which are labels, and whether labels are float (regression) or categorical (classification).
+- **Check for a split column** (`split_random`, `split_stratified_<label>`, or a user-named one). If absent in h5ad, propose creating one (see `references/data_prep.md`).
+
+See `references/data_prep.md` for the exact snippets to run. Always confirm inferences with the user before writing the yaml.
+
+### 3. Choose the output shape
+
+The skill produces one of two artifacts:
+
+- **CLI one-liner** — for `predict` and `dna_predict`. Small, stateless, matches the repo README style. Put all overrides inline as `key=value` or `++key=value`.
+- **Yaml file** — for `finetune`, `pretrain`, `dna_finetune`, and `interpret`. Enough knobs that a one-liner becomes unreadable, and the user will want to rerun it. Write it under `configs/` in the repo root (or user-specified path), use plain `.yaml`, and produce a matching CLI one-liner that runs it with `-cd <dir> -cn <name>` or `--config-dir <dir> --config-name <name>`.
+
+### 4. Write the config
+
+- Start from the closest existing template: `run/<task_class>.yaml` for the overall shape; `run/checkpoints/<ckpt>.yaml` for everything the checkpoint requires. Don't re-derive fields that the checkpoint provenance already sets correctly.
+- **When `checkpoint=` is set, do NOT emit `tokenizer:`, `fields:`, or `model:` blocks in the user's yaml.** The framework loads all three from the checkpoint and whatever you put in the yaml is ignored (predict / interpret) or a footgun waiting to happen (finetune, where a mismatched field spec silently breaks head shapes). Read the provenance to *understand* what the checkpoint expects so you can set the right `data_module` overrides, but don't copy those blocks into the user's config. The only time these blocks should appear is when the user is pretraining from scratch (no `checkpoint=`) or deliberately extending the schema (rare).
+- **Label-name clash with pretrained heads.** A clash happens **if and only if** the user's `label_column_name` is *identical* to a name the checkpoint already has a head for (e.g. the v2 47m WCED has `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`, `sex`; the v1 BERT WCED multitask has `cell_type`, `tissue`, `donor_id`). When names match, Lightning tries to load pretrained head weights into the user's fresh head: if `n_unique_values` matches the pretrained head it loads silently with the wrong label-index meaning, and if it doesn't it fails with a shape mismatch. When the names differ, a fresh head is added and there is nothing to worry about. Rule: check the checkpoint's provenance yaml; if the user's column matches a name there, rename it (e.g. `cell_type` → `my_cell_type`); otherwise move on.
+- **At predict/test time**, `label_columns` works differently: the checkpoint's label_columns is authoritative and the YAML's is ignored (with a warning). Pass an explicit empty list (`label_columns: []`) to get embedding-only mode. Don't try to "use a different label column" at predict time; finetune first or run embedding-only.
+- Use `++` for fields that might not exist in the base config (the Hydra "add or override" operator). Use plain `key=value` for fields that definitely exist. Getting this wrong is a common Hydra error — see `references/overrides.md`.
+- For losses: read the user's problem type and the checkpoint's own losses, then propose. See `references/losses.md`.
+- For custom pretraining field/loss/tokenizer triples: see `references/fields_tokenizer.md`. This is deep lore; most users shouldn't need it.
+- **Split strategy matters more than people think.** Large pretrained RNA models learn donor / batch structure; a random split at finetune is too easy and generalization numbers will flatter the model. If the user has a `donor_id` or `batch` / `assay` / `dataset_id` column with ≥4 distinct values, propose a held-out-donor split (or held-out-batch) over `split_random`. If the grouping column has only 2–3 values it's not really splittable — note that to the user rather than pretending otherwise. See `references/data_prep.md` for snippets.
+- **Pooling method for inference and finetune heads.** The `pooling_method` knob on `trainer` controls how the sequence is reduced to a vector for downstream heads. Options: `"first_token"` (default, always valid), `"pooling_layer"` (only valid when the pooler was trained — i.e. sequence-classification or multitask checkpoints, NOT pure MLM), `"mean_pooling"`, an integer CLS index (e.g. `1`, `2` for the v2 47m's per-task CLS tokens), or a list like `[1, 2]` to concat multiple CLS tokens (e.g. S+T for CellXGene-style representations). For RDA-style `predict`, `first_token` (or `0`) is usually right. For finetuning off a multi-CLS v2 checkpoint, either pick the `decode_from` that matches the pretrained head closest to your task, or fall back to `first_token`. See `references/overrides.md`.
+
+### 5. Dry-run validate (always)
+
+Before telling the user "run this", invoke the Level-1 validator:
+
+```bash
+bash .claude/skills/bmfm-targets-run/scripts/dry_run.sh <args you were going to give the user>
+```
+
+It wraps `bmfm-targets-run ... --cfg job --resolve` to render the fully-resolved config without starting training. If it errors, fix the config before handing it over. If the user explicitly asks for a smoke test (Level 2), add `task.max_epochs=1 ++task.max_steps=5 data_module.num_workers=0 task.accelerator=cpu task.precision=32` to actually run a few steps.
+
+### 6. Hand off
+
+Give the user: the config file path (if any), the exact command line, a one-sentence note on what the command will produce and where, and any follow-up they'll likely want (e.g. `label_dict.json` will appear in `working_dir/`).
+
+## Default loss selection (short version)
+
+The long version is in `references/losses.md`. The short version:
+
+- **Classification (multi-class)**: `cross_entropy`. Switch to `focal` (γ=2) if classes are imbalanced.
+- **Binary classification**: `cross_entropy` with 2 classes is usually fine; `bce_with_logits` if the label is inherently binary float.
+- **Regression**: `mse`. Set `ignore_zero: true` if you're predicting expression-like values where most cells have zero.
+- **Multi-label (K independent binary targets)**: `bce_with_logits`.
+- **Cell Ontology cell type labels specifically**: `hce` (hierarchical cross-entropy). See the HCE section below — in practice this only applies to `cell_type_ontology_term_id` from CellXGene. For any other ontology-backed label you do **not** have the ontology wired in and must fall back to `cross_entropy` or `focal`.
+- **Multitask fine-tuning mirroring the checkpoint**: copy the checkpoint's loss block verbatim, then adapt the `label_column_name`s.
+- **Adversarial de-biasing (e.g. remove donor effects)**: set `gradient_reversal_coefficient` on the unwanted label's `LabelColumnInfo`; add a matching entry to `trainer.losses`. The v1 BERT WCED multitask checkpoint (coef 3.0, donor_id) and the v2 32m Llama MLM multitask (coef 1.0, donor_id) are the canonical references. Note: the v2 47m WCED llama does **not** use GRL — check the specific checkpoint's provenance.
+- **WCED**: requires BOTH `WCEDMasker` as the data_module's masking_strategy AND losses with `field_name: expressions` + `wced_target:`. The `wced_target` value is the user's choice: `input_genes`, `non_input_genes`, or `all_genes` — each is a different reconstruction objective. See `references/fields_tokenizer.md`.
+- **Any label loss requires a matching `LabelColumnInfo`** in `label_columns`. The loss binds an objective; the `LabelColumnInfo` defines the head shape (regression vs classification, n_classes, decode_from, GRL coef). Without the label_columns entry, instantiation fails.
+
+When you deviate from the checkpoint's defaults, explain why in one line.
+
+## HCE is narrower than it looks
+
+HCE (Hierarchical Cross-Entropy) requires a registered ontology with roll-up edges so the objective can charge partial credit for predicting an ancestor of the correct term. In the current codebase the only ontology wired in is `celltypeont` (Cell Ontology), used exclusively for the `cell_type_ontology_term_id` column from CellXGene. That's the only label for which `hce` is a real option today.
+
+Practical rules:
+
+- If the user is fine-tuning on CellXGene `cell_type_ontology_term_id` (the pretraining label for the v2 multitask checkpoints), `hce` is the natural match and lets the pretrained head init transfer cleanly. Set `label_ontology: celltypeont` on the `LabelColumnInfo`.
+- For any other label — including "cell type" columns with non-Cell-Ontology terms, or cell-type annotations the user made themselves — `hce` is not available. Use `cross_entropy` (or `focal` if imbalanced). Don't pretend otherwise; `hce` without a matching registered ontology will fail at instantiation.
+- If the user genuinely has a hierarchical label backed by a different ontology, registering it is out of scope for this skill — point them at `bmfm_targets/training/losses/objectives/hce.py` and the ontology loading code.
+
+## A note on input data units
+
+Every published RNA checkpoint was pretrained on **raw integer counts** that were then normalized internally (either by `log_normalize_transform` at CPM10k+log1p, or by an RDA mode that does its own log-normalization). Raw counts is the expected input for any downstream use. If the user's h5ad is already log-normalized, they can usually still fine-tune on a classification head (off-distribution but it converges), and maybe get usable embeddings via `predict`, but they should NOT run reconstruction / WCED / MLM / zero-shot prediction heads — the output distributions won't match. Ask them to re-obtain raw counts, or pick a different checkpoint. For RDA checkpoints specifically, refuse to proceed on log-normalized input — RDA operates on count-level values and will produce garbage. See `references/checkpoints.md` for the full policy.
+
+## Working directory and artifact policy
+
+- If the user provides `working_dir`, use it.
+- Otherwise default to `./outputs/<task_class>_<YYYYMMDD-HHMMSS>/` in the current repo, and tell the user where you're putting it.
+- `/tmp` is acceptable for one-off `predict` runs where the artifacts are disposable, but default to a persistent dir otherwise.
+- `predict` produces `embeddings.csv` and `predictions.csv` in `working_dir/`; `finetune` produces `labels.json` plus the usual Lightning checkpoints; `interpret` produces attribution maps.
+
+## Debugging existing yaml
+
+When the user pastes a failing config:
+
+1. Read the full Hydra error. The first stack line tells you where instantiation failed; the second tells you which field. `Error instantiating 'bmfm_targets.config.TrainerConfig': missing 1 required positional argument: losses` means `trainer.losses` is absent or empty.
+2. Run the dry-run script on their config before proposing fixes — it'll surface all resolution errors, not just the first.
+3. Common failures: `_partial_` missing on a data_module that takes kwargs later, `${oc.env:...}` referencing an unset env var, `++` needed because the field isn't in the base schema, `-cd run` forgotten so Hydra can't find the named config.
+
+See `references/overrides.md` for the full gotcha list.
+
+## When to go deep
+
+Don't read every reference file every time. Load on demand:
+
+- `references/checkpoints.md` — **before writing any config that names a checkpoint.** Has the v1 + v2 roster and how to infer overrides from provenance.
+- `references/losses.md` — when the user's problem type isn't obviously covered by the checkpoint's losses.
+- `references/overrides.md` — when a yaml fails with a Hydra error, or when the user asks about `++` vs `.` vs defaults-list override semantics.
+- `references/data_prep.md` — when the user has an h5ad / csv that isn't split-ready, or when you need to inspect what label columns exist.
+- `references/interpret.md` — for any interpret task.
+- `references/fields_tokenizer.md` — for custom pretraining: new tokenizer vocabs, new field/loss combinations, scale_adapt vs mlp_with_special_token_embedding, `decode_modes`.
+
+## Known limits
+
+- The skill does not currently cover `benchmark_configs/` or dataset conversion utilities (`h5ad2litdata`, `parquet2litdata`). Users asking for those should be pointed at `bmfm_targets/evaluation/benchmark_configs/README.md` and `bmfm_targets/datasets/data_conversion/`.
+- The skill assumes the current working directory is the repo root (or a subdirectory of it) when `run/` is present. If the user is elsewhere, tell them to `cd` or pass `--config-dir <abs path to run/>`.

--- a/.claude/skills/bmfm-targets-run/SKILL.md
+++ b/.claude/skills/bmfm-targets-run/SKILL.md
@@ -69,7 +69,7 @@ Always confirm inferences with the user before writing the yaml.
 - **When `checkpoint=` is set, do NOT emit `tokenizer:`, `fields:`, or `model:` blocks.** The framework loads all three from the checkpoint. Read provenance to understand what the checkpoint expects so you can set the right `data_module` overrides, but don't copy those blocks into the user's config.
 - **Label-name clash with pretrained heads.** A clash happens **if and only if** the user's `label_column_name` is identical to a name the checkpoint already has a head for (v2 47m WCED: `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`, `sex`; v1 BERT WCED multitask: `cell_type`, `tissue`, `donor_id`). Mismatched shapes fail loudly; matched shapes load silently with wrong label-index meaning. When names differ, a fresh head is added — nothing to worry about. Rule: check provenance; if the user's column matches a name there, rename it.
 - **At predict/test time**, `label_columns` in the YAML is ignored (the checkpoint's is authoritative). Pass `label_columns: []` for embedding-only mode.
-- Use `++` for fields that might not exist in the base config. Use plain `key=value` for fields that definitely exist. **Exception: `++trainer.pooling_method=<value>` is a known footgun** — Hydra creates `self.trainer` as a bare dict rather than a `TrainerConfig` dataclass, which then crashes at `.merge_from_checkpoint()` with `AttributeError: 'dict' object has no attribute 'merge_from_checkpoint'`. The fix is in `bmfm_targets/config/main_config.py` (~line 354); if you see this error and the fix is absent, add an `isinstance(self.trainer, dict)` guard there.
+- Use `++` for fields that might not exist in the base config. Use plain `key=value` for fields that definitely exist. For pooling, always use `trainer.pooling_method=<value>` — no `++`.
 - **Split strategy matters.** Large pretrained RNA models learn donor / batch structure; a random split at finetune is too easy. If the user has `donor_id` / `batch` / `dataset_id` with ≥4 distinct values, propose a held-out-donor split. See `references/data_prep.md`.
 - **Pooling method — always choose explicitly, never rely on checkpoint defaults.** See section below.
 
@@ -154,7 +154,7 @@ When comparing embeddings across several checkpoints on the same h5ad:
 1. Read the full Hydra error. The first stack frame says where instantiation failed; the second says which field.
 2. Run the dry-run script before proposing fixes — it surfaces all resolution errors, not just the first.
 3. Common failures: `_partial_` missing on a data_module; `${oc.env:...}` referencing an unset var; `++` needed for a field not in the base schema; `-cd run` forgotten.
-4. **`AttributeError: 'dict' object has no attribute 'merge_from_checkpoint'`** — caused by `++trainer.pooling_method=<value>` creating `self.trainer` as a bare dict. Fix is in `bmfm_targets/config/main_config.py` (~line 354): add an `isinstance(self.trainer, dict)` guard that merges dict overrides onto the checkpoint-loaded `TrainerConfig` before calling `.merge_from_checkpoint()`.
+4. **`AttributeError: 'dict' object has no attribute 'merge_from_checkpoint'`** — `trainer:` block is missing from the base yaml. Fix: ensure the base yaml has a `trainer:` stub (all shipped yamls under `run/` should have one). Then use `trainer.pooling_method=X` without `++`.
 
 See `references/overrides.md` for the full gotcha list.
 

--- a/.claude/skills/bmfm-targets-run/evals/evals.json
+++ b/.claude/skills/bmfm-targets-run/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "bmfm-targets-run",
+  "description": "Seven task prompts exercising the skill across the six scopes (predict, finetune, pretrain, dna_predict, dna_finetune, interpret) plus one arcane multitask + gradient-reversal case. Each prompt is phrased the way a real user would ask it, not in the framework's vocabulary.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "predict-rda-embeddings",
+      "prompt": "I have an h5ad file at /data/my_pbmc.h5ad with raw counts. I want zero-shot embeddings using the MLM+RDA v1 checkpoint. Give me the command.",
+      "expected_output": "A bmfm-targets-run -cd run -cn predict command with checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1, log_normalize_transform=false, and an rda_transform override (auto_align is the safe default). Active inspection of the h5ad should be offered. A dry-run validation step should be proposed before the user runs it.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "finetune-celltype",
+      "prompt": "I want to fine-tune a BMFM model on my data to classify cell types. The h5ad is /data/my_cells.h5ad. I don't know what checkpoint to pick.",
+      "expected_output": "A short recommendation of a checkpoint (WCED multitask v1 is a reasonable default), a data-inspection step (look at celltype column, class balance, split column presence), a finetune yaml or CLI that uses cross_entropy on the user's label column, and a dry-run.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "dna-regression-finetune",
+      "prompt": "I have a CSV directory /data/dna_csvs/ with train.csv, dev.csv, test.csv. Column 0 is sequence, columns 1 and 2 are two continuous expression values I want to predict jointly. Help me finetune the DNA ModernBERT checkpoint.",
+      "expected_output": "A dna_finetune yaml with two LabelColumnInfo entries (is_regression_label: true) and two mse losses, inspection of the csv before writing, and a dry-run using -cn dna_finetune_train_and_test_config.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "pretrain-from-scratch",
+      "prompt": "I want to pretrain a BMFM RNA model on my own h5ad from scratch (no checkpoint). The file is /data/atlas.h5ad. Walk me through it.",
+      "expected_output": "Recommends the llama architecture over scBERT (v2 outperforms per-param). Uses the pretrain_rda_mlm template or equivalent with tokenizer identifier protein_coding, scale_adapt expression encoder, expose_zeros: true paired with pad_zero_expression_strategy: batch_wise, log_normalize_transform: true (or rda_transform override if RDA is desired). Inspects h5ad for split column; proposes held-out-batch/donor split if a suitable grouping column is present. Dry-run before handing off.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "interpret-which-genes-matter",
+      "prompt": "I have a fine-tuned checkpoint at /ckpts/my_celltype.ckpt trained on the pbmc cell_type column. I want to know which genes the model uses to identify T cells vs B cells. Data subset at /data/subset.h5ad (500 cells).",
+      "expected_output": "An InterpretTaskConfig yaml that does NOT include model/tokenizer/fields blocks (they come from the checkpoint), with attribute_kwargs.n_steps=50, attribute_filter restricted to the specific classes the user asked about (e.g. T cell + B cell only, not all classes), limit_dataset_samples around 500, a warning that it's slow, confirmation that the checkpoint is a local .ckpt not a HuggingFace id, and a post-processing snippet using get_mean_attributions to produce the top-gene list with the highlight column.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "name": "finetune-label-name-clash",
+      "prompt": "I want to fine-tune ibm-research/biomed.rna.bert.110m.wced.multitask.v1 on my h5ad at /data/pbmc.h5ad to classify my 8 custom cell type annotations. My column is called `cell_type` and contains values like `my_T_helper_subset_1`. Help me write the config.",
+      "expected_output": "Correctly identifies the clash: the v1 BERT WCED multitask checkpoint has a pretrained head literally named `cell_type`, and the user's column has the same name. State-dict loading will try to push the pretrained head weights into the user's fresh 8-class head — either silently loading into a mis-mapped 8-class label space (if n_unique_values coincidentally matches) or failing with a shape mismatch (more likely). Recommends renaming the user's column to something non-clashing (e.g. `my_cell_type`) in ad.obs before training, and pointing `label_column_name` at the new name. Makes no claims about 'close enough' or partial matches — the rule is exact-name-match or no clash. Produces a finetune yaml WITHOUT tokenizer/fields/model blocks. Uses cross_entropy (or focal if imbalanced). Dry-run.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "finetune-grl-donor-debiasing",
+      "prompt": "I'm fine-tuning on cell_type but my data is from 3 donors and the model keeps latching onto donor-specific signal. How do I make the encoder ignore donor_id while still learning cell_type?",
+      "expected_output": "Proposes gradient reversal. Adds donor_id as a LabelColumnInfo with gradient_reversal_coefficient (~3.0, referencing the wced.multitask.v1 pattern), a matching trainer.losses entry with focal loss at weight 0.05, warns about the primary-vs-adversarial weight balance, points at finetune_with_grl.yaml in examples/ or produces the equivalent yaml, and does a dry-run.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/bmfm-targets-run/examples/dna_finetune_two_regression.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/dna_finetune_two_regression.yaml
@@ -1,0 +1,68 @@
+# DNA fine-tuning with two independent regression labels.
+#
+# Canonical use case: predicting two continuous properties of a sequence
+# (e.g. expression levels for two tissues) from the same encoder. Two
+# regression heads are attached, each supervised by MSE on its own column.
+#
+# Expected csv layout (same shape for train.csv, dev.csv, test.csv):
+#   col 0: nucleotide sequence (A/C/G/T string)
+#   col 1: label_a (float)
+#   col 2: label_b (float)
+#   (any trailing columns are ignored)
+#
+# CLI:
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name dna_finetune_two_regression \
+#     input_directory=/abs/path/csv_dir \
+#     working_dir=./outputs/dna_ft \
+#     checkpoint=ibm-research/biomed.dna.modernbert.113m.v1 \
+#     label_a=expression_tissue_a \
+#     label_b=expression_tissue_b
+
+defaults:
+  - data_module: dna_base_seq_cls
+  - tokenizer: ref2vec
+  - fields: dna_chunks
+  - trainer: default
+  - task: train_and_test
+  - model: modernbert
+  - _self_
+
+seed:
+  seed_value: 1234
+
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_a}
+    is_regression_label: true
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_b}
+    is_regression_label: true
+
+data_module:
+  batch_size: ${batch_size}
+  dataset_kwargs:
+    processed_data_source: ${input_directory}
+    dataset_name: ${dataset_name}
+    label_dict_path: ${input_directory}/${dataset_name}_all_labels.json
+
+trainer:
+  learning_rate: ${learning_rate}
+  losses:
+    - label_column_name: ${label_a}
+      name: mse
+    - label_column_name: ${label_b}
+      name: mse
+
+batch_size: 32
+learning_rate: 1e-5
+dataset_name: my_dataset
+label_a: label_a
+label_b: label_b
+checkpoint: null
+accelerator: gpu
+input_directory: null
+working_dir: /tmp/dna_ft
+max_epochs: 5
+val_check_interval: 0.5

--- a/.claude/skills/bmfm-targets-run/examples/dna_predict.sh
+++ b/.claude/skills/bmfm-targets-run/examples/dna_predict.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Zero-shot embeddings + predictions from a DNA (ModernBERT) checkpoint on a csv.
+#
+# DNA inference expects a directory containing {train,test,dev}.csv. Column 0
+# is the nucleotide sequence; remaining columns are labels (ignored at predict
+# time but must be present structurally).
+#
+# Usage:
+#   INPUT_DIR=/path/to/csvs INPUT_FILENAME=test.csv WORKING_DIR=/path/to/out \
+#     bash dna_predict.sh
+
+set -euo pipefail
+
+: "${INPUT_DIR:?set INPUT_DIR=/path/to/csv_directory}"
+: "${INPUT_FILENAME:=test.csv}"
+: "${WORKING_DIR:=./outputs/dna_predict}"
+: "${CHECKPOINT:=ibm-research/biomed.dna.modernbert.113m.v1}"
+: "${DATASET_NAME:=coreprom}"
+
+bmfm-targets-run -cd run -cn dna_predict \
+  input_directory="$INPUT_DIR" \
+  input_filename="$INPUT_FILENAME" \
+  working_dir="$WORKING_DIR" \
+  checkpoint="$CHECKPOINT" \
+  dataset_name="$DATASET_NAME"

--- a/.claude/skills/bmfm-targets-run/examples/finetune_celltype.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/finetune_celltype.yaml
@@ -1,0 +1,88 @@
+# Fine-tune a BMFM RNA checkpoint on a single categorical label (e.g. cell_type).
+#
+# This is the "most requested" pattern. It layers a classification head on top
+# of the pretrained encoder and trains only the new head + encoder.
+#
+# Defaults here match the v1 WCED/MLM-multitask checkpoints:
+#   - log_normalize_transform: true   (these checkpoints want log-normalized input)
+#   - max_length: 1024                (training value; can be smaller at finetune)
+#   - cross_entropy                   (baseline; switch to focal if imbalanced)
+#
+# For the MLM+RDA checkpoint, override at the CLI:
+#   data_module.log_normalize_transform=false  (RDA wants raw counts)
+#   ++data_module.rda_transform=auto_align     (or downsample)
+#
+# CLI:
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name finetune_celltype \
+#     input_file=/abs/path/data.h5ad \
+#     working_dir=./outputs/ft_celltype \
+#     checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 \
+#     label_column_name=celltype \
+#     split_column_name=split_random
+
+defaults:
+  - override hydra/hydra_logging: disabled
+  - override hydra/job_logging: disabled
+
+seed:
+  seed_value: 1234
+
+# tokenizer:, fields:, and model: are deliberately omitted. When `checkpoint=`
+# is passed, the framework rehydrates all three from the checkpoint. Hardcoding
+# them here is at best noise; at worst a silent mismatch when checkpoints use
+# different vocabs (v2 Llama uses `protein_coding`, v1 BERT uses `all_genes`)
+# or different expression encoders (v1 WCED uses mlp_with_special_token_embedding,
+# v2 uses scale_adapt).
+
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_column_name}
+    is_regression_label: false
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  num_workers: 4
+  batch_size: 16
+  max_length: 1024
+  limit_genes: protein_coding
+  log_normalize_transform: true
+  transform_datasets: false
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    label_dict_path: ${working_dir}/labels.json
+    split_column_name: ${split_column_name}
+
+trainer:
+  _target_: bmfm_targets.config.TrainerConfig
+  warmup_steps: 100
+  weight_decay: 0.01
+  learning_rate: 5.0e-05
+  losses:
+    - label_column_name: ${label_column_name}
+      name: cross_entropy
+      metrics:
+        - name: accuracy
+        - name: f1
+        - name: precision
+        - name: recall
+
+task:
+  _target_: bmfm_targets.config.TrainingTaskConfig
+  default_root_dir: ${working_dir}
+  max_epochs: ${max_epochs}
+  val_check_interval: ${val_check_interval}
+  precision: 16-mixed
+  accelerator: ${accelerator}
+  checkpoint: ${checkpoint}
+
+input_file: null
+working_dir: /tmp/ft_celltype
+checkpoint: null
+split_column_name: split_random
+label_column_name: celltype
+max_epochs: 5
+val_check_interval: 0.5
+accelerator: gpu

--- a/.claude/skills/bmfm-targets-run/examples/finetune_with_grl.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/finetune_with_grl.yaml
@@ -1,0 +1,106 @@
+# Fine-tune with gradient reversal: classify cell_type while actively removing
+# donor_id signal from the representation.
+#
+# This pattern mirrors run/checkpoints/biomed.rna.bert.110m.wced.multitask.v1.yaml,
+# where donor_id has gradient_reversal_coefficient: 3.0 with a focal loss at
+# weight 0.05. The combination is deliberate: the high GRL coefficient flips the
+# gradient aggressively, but the small loss weight keeps the adversarial signal
+# from dominating the primary cell_type objective.
+#
+# When to use this:
+#   - You have a nuisance variable (donor / batch / site) in the h5ad obs
+#   - Downstream task performance is hurt by spurious correlations with it
+#   - You want the encoder to be invariant to the nuisance
+#
+# Don't use this if the nuisance is not actually a confound — the adversarial
+# signal is expensive and can hurt primary task quality if applied gratuitously.
+#
+# CLI:
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name finetune_with_grl \
+#     input_file=/abs/path/data.h5ad \
+#     working_dir=./outputs/ft_grl \
+#     checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 \
+#     label_column_name=celltype \
+#     nuisance_label_name=donor_id \
+#     split_column_name=split_random
+
+seed:
+  seed_value: 1234
+
+tokenizer:
+  _target_: bmfm_targets.config.TokenizerConfig
+  identifier: all_genes
+
+fields:
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: genes
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: expressions
+    tokenization_strategy: continuous_value_encoder
+    encoder_kwargs:
+      kind: mlp_with_special_token_embedding
+      zero_as_special_token: true
+
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_column_name}
+    is_regression_label: false
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${nuisance_label_name}
+    gradient_reversal_coefficient: 3.0
+    silent_label_values:
+      - unknown
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  num_workers: 4
+  batch_size: 16
+  max_length: 1024
+  limit_genes: protein_coding
+  log_normalize_transform: true
+  transform_datasets: false
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    label_dict_path: ${working_dir}/labels.json
+    split_column_name: ${split_column_name}
+
+trainer:
+  _target_: bmfm_targets.config.TrainerConfig
+  warmup_steps: 100
+  weight_decay: 0.01
+  learning_rate: 5.0e-05
+  losses:
+    # Primary task — dominates
+    - label_column_name: ${label_column_name}
+      weight: 1.0
+      name: cross_entropy
+      metrics:
+        - name: accuracy
+        - name: f1
+    # Adversarial — small weight, gradient sign flipped by GRL on the column
+    - label_column_name: ${nuisance_label_name}
+      weight: 0.05
+      name: focal
+      focal_gamma: 2
+
+task:
+  _target_: bmfm_targets.config.TrainingTaskConfig
+  default_root_dir: ${working_dir}
+  max_epochs: ${max_epochs}
+  val_check_interval: ${val_check_interval}
+  precision: 16-mixed
+  accelerator: ${accelerator}
+  checkpoint: ${checkpoint}
+
+input_file: null
+working_dir: /tmp/ft_grl
+checkpoint: null
+split_column_name: split_random
+label_column_name: celltype
+nuisance_label_name: donor_id
+max_epochs: 5
+val_check_interval: 0.5
+accelerator: gpu

--- a/.claude/skills/bmfm-targets-run/examples/interpret_from_checkpoint.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/interpret_from_checkpoint.yaml
@@ -1,0 +1,74 @@
+# Captum-based attribution over a fine-tuned checkpoint.
+#
+# Produces per-sample, per-gene attribution scores toward a chosen label class.
+# Uses Integrated Gradients (n_steps=50 is a reasonable default).
+#
+# Requirements:
+#   - Local .ckpt file (not just a HuggingFace id). The full Lightning checkpoint
+#     is needed; HF exports may not contain everything the attribution loop expects.
+#   - A small data subset (~100-500 cells). Attribution runs one sample at a time
+#     with 50 forward+backward passes each; it's slow.
+#   - The checkpoint's fields / encoder must match this yaml exactly. Copy them
+#     from the training yaml the checkpoint was produced with.
+#
+# CLI:
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name interpret_from_checkpoint \
+#     input_file=/abs/path/data.h5ad \
+#     working_dir=./outputs/interpret \
+#     checkpoint=/abs/path/to/model.ckpt \
+#     label_column_name=celltype
+
+defaults:
+  - _self_
+
+seed:
+  seed_value: 1234
+
+tokenizer:
+  _target_: bmfm_targets.config.TokenizerConfig
+  identifier: all_genes  # must match the checkpoint; change if pretrained with a different vocab
+
+fields:
+  # Copy these from the checkpoint's training yaml. Fields/encoder mismatches
+  # silently produce garbage attributions.
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: genes
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: expressions
+    tokenization_strategy: continuous_value_encoder
+    encoder_kwargs:
+      kind: mlp_with_special_token_embedding
+      zero_as_special_token: true
+
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_column_name}
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  num_workers: 4
+  max_length: 512
+  limit_dataset_samples: 200   # attribution is slow; cap the sample count
+  log_normalize_transform: true
+  limit_genes: protein_coding
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    label_dict_path: ${working_dir}/labels.json
+
+task:
+  _target_: bmfm_targets.config.InterpretTaskConfig
+  default_root_dir: ${working_dir}
+  accelerator: gpu
+  precision: 16-mixed
+  tf32_mode: medium
+  attribute_kwargs:
+    n_steps: 50    # Integrated Gradients steps; drop to 20 if OOM or too slow
+  checkpoint: ${checkpoint}
+
+input_file: null
+working_dir: /tmp/interpret
+checkpoint: null
+label_column_name: celltype

--- a/.claude/skills/bmfm-targets-run/examples/predict_llama_v2.sh
+++ b/.claude/skills/bmfm-targets-run/examples/predict_llama_v2.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Zero-shot embeddings from a v2 (March 2026) Llama checkpoint.
+#
+# v2 checkpoints were trained with scale_adapt encoder + log-normalized input,
+# max_length 8192. They're smaller (~32-47M params) and use Llama arch instead
+# of BERT. Set CHECKPOINT to either:
+#   ibm-research/biomed.rna.llama.32m.mlm.multitask.v1   (MLM + multitask)
+#   ibm-research/biomed.rna.llama.47m.wced.multitask.v1  (WCED + multitask)
+#
+# Usage:
+#   INPUT_FILE=/path/to/data.h5ad WORKING_DIR=/path/to/out \
+#     CHECKPOINT=ibm-research/biomed.rna.llama.47m.wced.multitask.v1 \
+#     bash predict_llama_v2.sh
+
+set -euo pipefail
+
+: "${INPUT_FILE:?set INPUT_FILE=/path/to/data.h5ad}"
+: "${WORKING_DIR:=./outputs/predict_llama_v2}"
+: "${CHECKPOINT:=ibm-research/biomed.rna.llama.47m.wced.multitask.v1}"
+
+bmfm-targets-run -cd run -cn predict \
+  input_file="$INPUT_FILE" \
+  working_dir="$WORKING_DIR" \
+  checkpoint="$CHECKPOINT" \
+  data_module.log_normalize_transform=true \
+  data_module.max_length=2048

--- a/.claude/skills/bmfm-targets-run/examples/predict_mlm_rda.sh
+++ b/.claude/skills/bmfm-targets-run/examples/predict_mlm_rda.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Zero-shot embeddings + predictions from the MLM+RDA v1 checkpoint on an h5ad.
+#
+# This checkpoint expects RAW counts (not log-normalized) and applies its own
+# RDA transform internally. The two must-have overrides vs. the finetune/other
+# predict commands are:
+#   data_module.log_normalize_transform=false   (RDA wants raw)
+#   ++data_module.rda_transform=auto_align      (optional; default is downsample)
+#
+# Outputs land in $WORKING_DIR as embeddings.csv + predictions.csv.
+#
+# Usage:
+#   INPUT_FILE=/path/to/data.h5ad WORKING_DIR=/path/to/out bash predict_mlm_rda.sh
+
+set -euo pipefail
+
+: "${INPUT_FILE:?set INPUT_FILE=/path/to/data.h5ad}"
+: "${WORKING_DIR:=./outputs/predict_mlm_rda}"
+
+bmfm-targets-run -cd run -cn predict \
+  input_file="$INPUT_FILE" \
+  working_dir="$WORKING_DIR" \
+  checkpoint=ibm-research/biomed.rna.bert.110m.mlm.rda.v1 \
+  data_module.log_normalize_transform=false \
+  data_module.max_length=1024 \
+  ++data_module.rda_transform=auto_align

--- a/.claude/skills/bmfm-targets-run/examples/predict_template.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/predict_template.yaml
@@ -1,0 +1,57 @@
+# Fallback predict template for pip-installed environments where `run/` isn't
+# present. Matches the shape of `run/predict.yaml` in the repo.
+#
+# CLI (when the repo is cloned, prefer `-cd run -cn predict` instead):
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name predict_template \
+#     input_file=/abs/path/data.h5ad \
+#     working_dir=./outputs/predict \
+#     checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1
+
+defaults:
+  - _self_
+
+seed:
+  seed_value: 1234
+
+tokenizer:
+  _target_: bmfm_targets.config.TokenizerConfig
+  identifier: all_genes
+
+fields:
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: genes
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: expressions
+    tokenization_strategy: continuous_value_encoder
+    encoder_kwargs:
+      kind: mlp_with_special_token_embedding
+      zero_as_special_token: true
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  max_length: 1024
+  limit_genes: protein_coding
+  log_normalize_transform: true
+  transform_datasets: false
+  num_workers: 4
+  batch_size: 16
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    label_dict_path: ${working_dir}/labels.json
+
+task:
+  _target_: bmfm_targets.config.PredictTaskConfig
+  checkpoint: ${checkpoint}
+  output_embeddings: true
+  output_predictions: true
+  default_root_dir: ${working_dir}
+  accelerator: ${accelerator}
+  precision: 16-mixed
+
+input_file: null
+working_dir: /tmp/predict
+checkpoint: null
+accelerator: gpu

--- a/.claude/skills/bmfm-targets-run/examples/predict_wced_multitask.sh
+++ b/.claude/skills/bmfm-targets-run/examples/predict_wced_multitask.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Zero-shot embeddings + multitask predictions from the WCED+multitask v1 checkpoint.
+#
+# This checkpoint was trained with log-normalized input (log_normalize_transform=true)
+# and has classification heads for cell_type, tissue, tissue_general, donor_id,
+# suspension_type. The predict task dumps the CLS embedding + per-head predictions.
+#
+# Outputs land in $WORKING_DIR as embeddings.csv + predictions.csv.
+#
+# Usage:
+#   INPUT_FILE=/path/to/data.h5ad WORKING_DIR=/path/to/out bash predict_wced_multitask.sh
+
+set -euo pipefail
+
+: "${INPUT_FILE:?set INPUT_FILE=/path/to/data.h5ad}"
+: "${WORKING_DIR:=./outputs/predict_wced_multitask}"
+
+bmfm-targets-run -cd run -cn predict \
+  input_file="$INPUT_FILE" \
+  working_dir="$WORKING_DIR" \
+  checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 \
+  data_module.log_normalize_transform=true \
+  data_module.max_length=1024

--- a/.claude/skills/bmfm-targets-run/examples/pretrain_rda_mlm.yaml
+++ b/.claude/skills/bmfm-targets-run/examples/pretrain_rda_mlm.yaml
@@ -1,0 +1,133 @@
+# Llama MLM pretraining template — cold-start a new model from scratch, or
+# continue-pretrain an existing Llama checkpoint.
+#
+# As of v2 (March 2026), llama models outperform scBERT per-parameter; prefer
+# this template over an scBERT-based one unless you have a specific reason.
+#
+# Key invariants (match the v2 32m MLM multitask recipe):
+#   - tokenizer identifier: protein_coding   (~19k genes; pairs with limit_genes)
+#   - scale_adapt expression encoder         (handles wide count ranges robustly)
+#   - expose_zeros: all + pad_zero_expression_strategy: batch_wise
+#       zeros must be exposed AND subsampled; one without the other swamps input
+#   - log_normalize_transform: true          (v2 recipes normalize internally; see below)
+#
+# RDA note: `rda_transform` is an alternative normalization path. When set, RDA
+# takes over log-normalization internally and overrides `log_normalize_transform`.
+# For standard MLM pretraining (this template), leave `rda_transform` unset and
+# keep `log_normalize_transform: true`. If you want RDA-style training, add
+# `++data_module.rda_transform=downsample` (or `poisson_downsample`) and flip
+# `log_normalize_transform: false`.
+#
+# CLI:
+#   bmfm-targets-run \
+#     --config-dir .claude/skills/bmfm-targets-run/examples \
+#     --config-name pretrain_rda_mlm \
+#     input_file=/abs/path/data.h5ad \
+#     working_dir=./outputs/pretrain
+
+defaults:
+  - _self_
+
+seed:
+  seed_value: 1234
+
+tokenizer:
+  _target_: bmfm_targets.config.TokenizerConfig
+  identifier: protein_coding
+
+fields:
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: genes
+  - _target_: bmfm_targets.config.FieldInfo
+    field_name: expressions
+    is_masked: true
+    tokenization_strategy: continuous_value_encoder
+    encoder_kwargs:
+      kind: scale_adapt
+      n_sin_basis: 48
+      basis_scale: 0.01
+      trainable: false
+      zero_as_special_token: true
+    decode_modes:
+      - regression
+      - is_zero
+
+label_columns: []
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  num_workers: 8
+  mlm: true
+  shuffle: true
+  change_ratio: 0.15
+  mask_ratio: 0.95
+  max_length: 8192
+  padding: longest
+  sequence_order: random
+  switch_ratio: 0.0
+  batch_size: 8
+  limit_genes: protein_coding
+  log_normalize_transform: true
+  pad_zero_expression_strategy:
+    strategy: batch_wise
+    interleave_zero_ratio: 0.9
+    expressed_sample_ratio: 0.2
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    label_dict_path: ${working_dir}/labels.json
+    split_column_name: ${split_column_name}
+    expose_zeros: all          # required for v2-style pretraining; must pair
+                               # with pad_zero_expression_strategy above
+    raw_counts: true
+
+model:
+  _target_: bmfm_targets.models.predictive.llama.LlamaForMultiTaskConfig
+  _partial_: true
+  num_hidden_layers: 12
+  num_attention_heads: 12
+  hidden_act: gelu
+  hidden_size: 384
+  initializer_range: 0.02
+  layer_norm_eps: 1.0e-12
+  pad_token_id: 0
+  flex_attention: true
+  use_cache: true
+  attention: flex
+  checkpoint: ${checkpoint}
+
+trainer:
+  _target_: bmfm_targets.config.TrainerConfig
+  warmup_steps: 1000
+  weight_decay: 0.1
+  learning_rate: 1.0e-4
+  betas: [0.9, 0.99]
+  epsilon: 1.0e-8
+  losses:
+    - field_name: expressions
+      name: mse
+      ignore_zero: true
+    - field_name: expressions
+      name: is_zero_bce
+      weight: 1.5
+
+task:
+  _target_: bmfm_targets.config.TrainingTaskConfig
+  default_root_dir: ${working_dir}
+  max_epochs: ${max_epochs}
+  precision: 16-mixed
+  gradient_clip_val: 0.5
+  accelerator: ${accelerator}
+  max_steps: -1
+  tf32_mode: medium
+  accumulate_grad_batches: 2
+  resume_training_from_ckpt: true
+  checkpoints_every_n_train_steps: ${checkpoints_every_n_train_steps}
+
+input_file: null
+working_dir: /tmp/pretrain_llama
+accelerator: gpu
+max_epochs: 10
+checkpoints_every_n_train_steps: 10000
+checkpoint: null
+split_column_name: split_random

--- a/.claude/skills/bmfm-targets-run/references/checkpoints.md
+++ b/.claude/skills/bmfm-targets-run/references/checkpoints.md
@@ -49,15 +49,18 @@ As of April 2026 the v2 provenance yamls are now checked in under `run/checkpoin
 
 `trainer.pooling_method` selects how the encoder output becomes a vector for downstream heads. The right choice depends on what the checkpoint was trained with — see `references/overrides.md` for the full signature. Quick map:
 
-| Checkpoint | Recommended pooling | Reason |
-| --- | --- | --- |
-| `biomed.rna.bert.110m.mlm.rda.v1` | `"first_token"` (or `0`) | MLM-only pretraining; pooler head is untrained. |
-| `biomed.rna.bert.110m.mlm.multitask.v1` | `"pooling_layer"` OK, `"first_token"` safe | Multitask head trained; pooler saw label supervision. |
-| `biomed.rna.bert.110m.wced.*` | `"pooling_layer"` (multitask variant) or `"first_token"` | WCED variant has a trained pooler via the multitask heads. |
-| `biomed.rna.llama.32m.mlm.multitask.v1` | `"first_token"` or `"pooling_layer"` | Single CLS; multitask pretraining. |
-| `biomed.rna.llama.47m.wced.multitask.v1` | integer index matching the task's pretrained `decode_from`, or `[1, 2]` for S+T concat, fallback `"first_token"` | Five CLS tokens are routed per-label via `decode_from`; for a finetune head, pick the CLS that was closest to your task during pretraining. |
+**MPS note:** BERT models run fine on `task.accelerator=mps`. LLaMA v2 models also run on MPS after the `flex_attention` CPU/MPS fallback fix in `bmfm_targets/models/common/llama/llama_layers.py` (added April 2026 — see feedback memory). If you see `ValueError: FlexAttention is only supported on CUDA`, the patch is missing.
 
-When in doubt, use `"first_token"` — it's always valid and behaves predictably. `"pooling_layer"` on a pure MLM checkpoint will silently return an untrained projection.
+**Always emit `++trainer.pooling_method=<choice>` explicitly. Never rely on the checkpoint's stored default — it reflects pretraining setup, not inference intent, and using the wrong pooler silently degrades embedding quality.**
+
+| Checkpoint | Required pooling override | Reason |
+| --- | --- | --- |
+| `biomed.rna.bert.110m.mlm.rda.v1` | `++trainer.pooling_method=first_token` | MLM-only; pooler is untrained — `pooling_layer` produces garbage. |
+| `biomed.rna.bert.110m.mlm.multitask.v1` | `++trainer.pooling_method=pooling_layer` | Pooler explicitly trained via multitask classification heads. |
+| `biomed.rna.bert.110m.wced.v1` | `++trainer.pooling_method=first_token` | WCED-only (no multitask heads); pooler not trained for downstream tasks. |
+| `biomed.rna.bert.110m.wced.multitask.v1` | `++trainer.pooling_method=first_token` | Pooler was trained, but `first_token` gives the raw CLS without the Linear projection — prefer this for general embeddings. Use `pooling_layer` only when the projected representation is specifically desired. |
+| `biomed.rna.llama.32m.mlm.multitask.v1` | `++trainer.pooling_method=pooling_layer` | Single CLS; pooler trained via multitask heads (HCE cell type, focal tissue/tissue_general). |
+| `biomed.rna.llama.47m.wced.multitask.v1` | `++trainer.pooling_method=1` (cell type), `2` (tissue), `[1,2]` (combined) | Five CLS tokens; `decode_from` routes each label to a specific CLS. Pick the CLS closest to your task. `first_token` is a fallback if task is ambiguous. |
 
 ## How to use provenance
 

--- a/.claude/skills/bmfm-targets-run/references/checkpoints.md
+++ b/.claude/skills/bmfm-targets-run/references/checkpoints.md
@@ -51,16 +51,16 @@ As of April 2026 the v2 provenance yamls are now checked in under `run/checkpoin
 
 **MPS note:** BERT models run fine on `task.accelerator=mps`. LLaMA v2 models also run on MPS after the `flex_attention` CPU/MPS fallback fix in `bmfm_targets/models/common/llama/llama_layers.py` (added April 2026 — see feedback memory). If you see `ValueError: FlexAttention is only supported on CUDA`, the patch is missing.
 
-**Always emit `++trainer.pooling_method=<choice>` explicitly. Never rely on the checkpoint's stored default — it reflects pretraining setup, not inference intent, and using the wrong pooler silently degrades embedding quality.**
+**Always set `trainer.pooling_method=<choice>` explicitly. Never rely on the checkpoint's stored default — it reflects pretraining setup, not inference intent, and using the wrong pooler silently degrades embedding quality.**
 
 | Checkpoint | Required pooling override | Reason |
 | --- | --- | --- |
-| `biomed.rna.bert.110m.mlm.rda.v1` | `++trainer.pooling_method=first_token` | MLM-only; pooler is untrained — `pooling_layer` produces garbage. |
-| `biomed.rna.bert.110m.mlm.multitask.v1` | `++trainer.pooling_method=pooling_layer` | Pooler explicitly trained via multitask classification heads. |
-| `biomed.rna.bert.110m.wced.v1` | `++trainer.pooling_method=first_token` | WCED-only (no multitask heads); pooler not trained for downstream tasks. |
-| `biomed.rna.bert.110m.wced.multitask.v1` | `++trainer.pooling_method=first_token` | Pooler was trained, but `first_token` gives the raw CLS without the Linear projection — prefer this for general embeddings. Use `pooling_layer` only when the projected representation is specifically desired. |
-| `biomed.rna.llama.32m.mlm.multitask.v1` | `++trainer.pooling_method=pooling_layer` | Single CLS; pooler trained via multitask heads (HCE cell type, focal tissue/tissue_general). |
-| `biomed.rna.llama.47m.wced.multitask.v1` | `++trainer.pooling_method=1` (cell type), `2` (tissue), `[1,2]` (combined) | Five CLS tokens; `decode_from` routes each label to a specific CLS. Pick the CLS closest to your task. `first_token` is a fallback if task is ambiguous. |
+| `biomed.rna.bert.110m.mlm.rda.v1` | `trainer.pooling_method=first_token` | MLM-only; pooler is untrained — `pooling_layer` produces garbage. |
+| `biomed.rna.bert.110m.mlm.multitask.v1` | `trainer.pooling_method=pooling_layer` | Pooler explicitly trained via multitask classification heads. |
+| `biomed.rna.bert.110m.wced.v1` | `trainer.pooling_method=first_token` | WCED-only (no multitask heads); pooler not trained for downstream tasks. |
+| `biomed.rna.bert.110m.wced.multitask.v1` | `trainer.pooling_method=first_token` | Pooler was trained, but `first_token` gives the raw CLS without the Linear projection — prefer this for general embeddings. Use `pooling_layer` only when the projected representation is specifically desired. |
+| `biomed.rna.llama.32m.mlm.multitask.v1` | `trainer.pooling_method=pooling_layer` | Single CLS; pooler trained via multitask heads (HCE cell type, focal tissue/tissue_general). |
+| `biomed.rna.llama.47m.wced.multitask.v1` | `trainer.pooling_method=1` (cell type), `2` (tissue), `[1,2]` (combined) | Five CLS tokens; `decode_from` routes each label to a specific CLS. Pick the CLS closest to your task. `first_token` is a fallback if task is ambiguous. |
 
 ## How to use provenance
 

--- a/.claude/skills/bmfm-targets-run/references/checkpoints.md
+++ b/.claude/skills/bmfm-targets-run/references/checkpoints.md
@@ -1,0 +1,94 @@
+# Checkpoint provenance
+
+Every published BMFM checkpoint has a training config that fully specifies what data, what objective, what tokenizer, and what model shape it was trained with. **The training config IS the provenance.** When the user names a checkpoint, read its training config before writing any override.
+
+## V1 checkpoints (BERT-110M, July 2025 preprint)
+
+Training configs live under `run/checkpoints/` in this repo. If the user has the repo cloned, read the file directly — it's the full truth.
+
+| HuggingFace id | Training config | Shape | Data | Key overrides |
+| --- | --- | --- | --- | --- |
+| `ibm-research/biomed.rna.bert.110m.mlm.rda.v1` | `run/checkpoints/biomed.rna.bert.110m.mlm.rda.v1.yaml` | BERT 12L/12H/768, 110M | CellXGene 1% equal-downsample, raw counts | `data_module.log_normalize_transform=false`, `data_module.max_length=4096`, RDA via `++data_module.rda_transform=auto_align` (or `downsample` / an integer) |
+| `ibm-research/biomed.rna.bert.110m.mlm.multitask.v1` | `run/checkpoints/biomed.rna.bert.110m.mlm.multitask.v1.yaml` | BERT 12L/12H/768, 110M | CellXGene 1% equal-downsample, log-normalized | `data_module.max_length=4096` |
+| `ibm-research/biomed.rna.bert.110m.wced.v1` | `run/checkpoints/biomed.rna.bert.110m.wced.v1.yaml` | BERT 12L/12H/768, 110M | CellXGene 1% random, log-normalized, WCED masker | defaults OK |
+| `ibm-research/biomed.rna.bert.110m.wced.multitask.v1` | `run/checkpoints/biomed.rna.bert.110m.wced.multitask.v1.yaml` | BERT 12L/12H/768, 110M | CellXGene 1% random, log-normalized, WCED + multitask (HCE for cell_type, focal for tissue/tissue_general/donor_id with GRL) | defaults OK |
+
+**DNA (from the July 2025 preprint):**
+
+| HuggingFace id | Architecture | Notes |
+| --- | --- | --- |
+| `ibm-research/biomed.dna.ref.modernbert.113m.v1` | ModernBERT 113M | MLM on reference human genome (GRCh38) |
+| `ibm-research/biomed.dna.snp.modernbert.113m.v1` | ModernBERT 113M | MLM on SNP-imputed genome using GWAS catalog + ClinVar variants |
+
+## V2 checkpoints (Llama, March 2026 preprint)
+
+As of April 2026 the v2 provenance yamls are now checked in under `run/checkpoints/`. Read them directly — they are authoritative. The preprint (`arxiv 2506.14861` v2, Table `tab:hyperparams_detailed`) covers the same material with less detail.
+
+| HuggingFace id | Training config | Shape | Objective | Key overrides |
+| --- | --- | --- | --- | --- |
+| `ibm-research/biomed.rna.llama.32m.mlm.multitask.v1` | `run/checkpoints/biomed.rna.llama.32m.mlm.multitask.v1.yaml` | Llama 12L/12H/384, ~32M | MLM Multitask | `change_ratio: 0.15`, `mask_ratio: 0.95`, HCE on cell_type, focal on tissue/tissue_general, **GRL on donor_id (coef 1.0, loss weight 0.05)** |
+| `ibm-research/biomed.rna.llama.47m.wced.multitask.v1` | `run/checkpoints/biomed.rna.llama.47m.wced.multitask.v1.yaml` | Llama 12L/12H/384, ~47M | WCED Multitask | `sequence_dropout_ratio: 0.2`, `WCEDMasker` + WCED losses on `all_genes`, **multiple CLS tokens (`prepend_tokens: [CLS, CLS_0..CLS_3]`) with per-label `decode_from` routing** |
+
+**Shared v2 training setup** (read from both yamls):
+
+- Dataset: CellXGene Nexus Index, 10% random split, ~5M cells
+- `max_length: 8192` (ceiling, not a requirement at inference)
+- `precision: 16-mixed`, `tf32_mode: medium`
+- `learning_rate: 1e-4`, `weight_decay: 0.10`, `warmup_steps: 1000`
+- Per-GPU `batch_size: 8`, `accumulate_grad_batches: 2`, 4× A100 80GB
+- `tokenizer.identifier: protein_coding`, `limit_genes: protein_coding`
+- `log_normalize_transform: true` (data is raw counts in the underlying dataset; both checkpoints normalize internally). RDA is not used.
+- Expression encoder: `scale_adapt` with `n_sin_basis: 48`, `basis_scale: 0.01`, `trainable: false`, `zero_as_special_token: true` (not `mlp_with_special_token_embedding` like v1 WCED)
+- Zero-expression strategy: `batch_wise`, `interleave_zero_ratio: 0.9`, `expressed_sample_ratio: 0.2`
+
+**MLM-specific (32m):** decode_modes `[regression, is_zero]` on expressions; single `[CLS]`; expressions losses are `mse` (ignore_zero) + `is_zero_bce` (weight 1.5). Donor_id is adversarial via `gradient_reversal_coefficient: 1.0`.
+
+**WCED-specific (47m):** decode_modes `{wced: {vocab_field: genes, logit_outputs: [mse, is_zero_bce]}}` on expressions; five prepend tokens and label-to-CLS routing via `decode_from` (see `references/fields_tokenizer.md` for how `decode_from` works); WCED losses target `all_genes` (active, weight 1.0) plus `input_genes` and `non_input_genes` (zeroed weights, present for head compatibility). HCE for cell_type_ontology_term_id, focal for tissue/tissue_general/donor_id/sex; **donor_id has no GRL here** (different from the 32m).
+
+## Pooling method by checkpoint
+
+`trainer.pooling_method` selects how the encoder output becomes a vector for downstream heads. The right choice depends on what the checkpoint was trained with — see `references/overrides.md` for the full signature. Quick map:
+
+| Checkpoint | Recommended pooling | Reason |
+| --- | --- | --- |
+| `biomed.rna.bert.110m.mlm.rda.v1` | `"first_token"` (or `0`) | MLM-only pretraining; pooler head is untrained. |
+| `biomed.rna.bert.110m.mlm.multitask.v1` | `"pooling_layer"` OK, `"first_token"` safe | Multitask head trained; pooler saw label supervision. |
+| `biomed.rna.bert.110m.wced.*` | `"pooling_layer"` (multitask variant) or `"first_token"` | WCED variant has a trained pooler via the multitask heads. |
+| `biomed.rna.llama.32m.mlm.multitask.v1` | `"first_token"` or `"pooling_layer"` | Single CLS; multitask pretraining. |
+| `biomed.rna.llama.47m.wced.multitask.v1` | integer index matching the task's pretrained `decode_from`, or `[1, 2]` for S+T concat, fallback `"first_token"` | Five CLS tokens are routed per-label via `decode_from`; for a finetune head, pick the CLS that was closest to your task during pretraining. |
+
+When in doubt, use `"first_token"` — it's always valid and behaves predictably. `"pooling_layer"` on a pure MLM checkpoint will silently return an untrained projection.
+
+## How to use provenance
+
+When the user says "I want to run `biomed.rna.bert.110m.wced.multitask.v1` for cell-type finetuning on my data":
+
+1. **Read the checkpoint's yaml** (`run/checkpoints/biomed.rna.bert.110m.wced.multitask.v1.yaml`). Note: `max_length: 1024`, `log_normalize_transform: true`, `limit_genes: protein_coding`, expressions field uses `mlp_with_special_token_embedding` encoder, losses include WCED decoder outputs + multitask head losses.
+2. **Start from `run/finetune.yaml`** — it defines the finetuning skeleton.
+3. **Carry forward from the checkpoint**: `max_length`, `log_normalize_transform`, `limit_genes`, expressions field encoder. These are load-bearing — changing them silently will break loading or silently produce wrong outputs.
+4. **Replace the pretraining losses with the finetuning loss(es).** The checkpoint's multitask loss block is for pretraining; for fine-tuning on one new column use `cross_entropy` (or whichever is right — see `losses.md`).
+5. **Override the paths**: `input_file`, `working_dir`, `label_column_name`, `split_column_name`.
+6. **Document what came from the checkpoint vs. what's new** in a yaml comment at the top, so the user can audit.
+
+## What "provenance" does NOT tell you
+
+- The exact Hydra defaults list that was active (this can change between runs). Always regenerate defaults from the current `run/finetune.yaml` or `run/predict.yaml` base.
+- Whether the user's data is in the same units as the pretraining corpus.
+
+### Input data: raw counts is the expected format
+
+**Every published BMFM RNA checkpoint was pretrained on raw integer counts**, normalized to a library size of 10,000 followed by `log1p` — either by `log_normalize_transform: true` at the data_module level, or internally by an RDA transform. Raw counts is the only fully-supported input format. When in doubt, assume the user needs raw counts and warn them if their h5ad looks normalized (non-integer values, max(X) ≪ 1000).
+
+What happens when the user's h5ad is already normalized (float values, typical max ~6–10):
+
+- **Fine-tuning on a classification head**: usually works, but is silently off-distribution. The encoder was trained on log1p(CPM10k), not on whatever normalization the user applied; representations may be worse but training will converge.
+- **Representation extraction (zero-shot embeddings via `predict`)**: may work if the prior normalization was `log1p(CPM10k)` or very close. Otherwise representations are untrustworthy.
+- **Zero-shot prediction of the pretraining labels, or any reconstruction / WCED / MLM head output**: do NOT proceed. The decoder heads expect log1p(CPM10k) distribution and will produce garbage. Tell the user explicitly to either re-normalize from raw counts or pick a different checkpoint.
+- **RDA checkpoints** (`biomed.rna.bert.110m.mlm.rda.v1`): require raw integer counts. RDA operates at the count level (downsample / align total reads) before log-normalizing internally. If the user has log-normalized data, strongly warn them NOT to proceed and either re-obtain raw counts or switch to a non-RDA checkpoint.
+- The batch size / GPU config — these are hardware-specific and should be set from the user's machine, not copied from the pretraining run.
+
+## CI as a minimum-viable-overrides cheat sheet
+
+`.github/workflows/test-cli.yml` contains the minimum override set that makes each checkpoint actually run on CPU with a tiny h5ad. These are the tested-in-CI recipes; when in doubt, check that file for the exact override string.
+
+One subtle bit from CI: **all v1 predict invocations use `data_module.log_normalize_transform=false` except the ones where it's already false** — this is a v1 test-path quirk (the pbmc3k sample is raw counts), not a universal rule. For user data that is log-normalized, omit this override.

--- a/.claude/skills/bmfm-targets-run/references/data_prep.md
+++ b/.claude/skills/bmfm-targets-run/references/data_prep.md
@@ -1,0 +1,164 @@
+# Data preparation and active inspection
+
+Before writing any config, look at what the user actually has. This file contains the snippets.
+
+## Inspecting an h5ad
+
+Always run this before picking a label column or confirming data format:
+
+```python
+import scanpy as sc
+ad = sc.read_h5ad("<user path>")
+print("shape:", ad.shape)
+print("obs columns:")
+print(ad.obs.dtypes)
+print("\ncandidate label columns (categorical / small unique count):")
+for col in ad.obs.columns:
+    n = ad.obs[col].nunique()
+    if n <= 100:
+        print(f"  {col}: {n} unique  (dtype={ad.obs[col].dtype})")
+print("\nis there a split column?")
+split_cols = [c for c in ad.obs.columns if c.startswith("split")]
+print(" ", split_cols or "no; will need to create one")
+print("\nare counts raw or normalized?  max(X)=", ad.X.max(), "; any decimals?", (ad.X.data % 1 != 0).any() if hasattr(ad.X, "data") else "(dense)")
+```
+
+What to infer from the output:
+
+- **Label column**: small unique count + categorical dtype = classification; float dtype = regression.
+- **Split column**: only needed for **training / finetuning**. `predict` runs over the full h5ad — don't invent a split column for it. If training and a column is present, use its name in `split_column_name=`. If training and absent, create one (see below). Values must be the literal strings `"train"`, `"dev"`, `"test"`.
+- **Raw vs. normalized**: the framework ships a helper — `from bmfm_targets.datasets.datasets_utils import guess_if_raw; guess_if_raw(ad.X.data)` returns True/False. Use it instead of eyeballing. If raw → most checkpoints want `data_module.log_normalize_transform=true`; the v1 RDA checkpoint wants `log_normalize_transform=false` (RDA normalizes internally). If already log-normalized, set `log_normalize_transform=false`.
+- **Gene identifiers**: `ad.var_names[:5]` should be gene symbols (e.g. `ENSG00000141510`, `TP53`). If they're Ensembl ids and the tokenizer expects symbols, the package has a mapping — see `bmfm_targets/transforms/protein_coding_gene_mapping_*.json`.
+
+## Creating a split column
+
+The split column values must be the literal strings `"train"`, `"dev"`, `"test"` — not `"val"`, `"validation"`, `"eval"`, or integer codes. The framework does a string-equality lookup against those three. Rows with other values are dropped silently.
+
+**Quick random split** (80/10/10):
+
+```python
+import scanpy as sc
+import bmfm_targets.datasets.datasets_utils as du
+
+ad = sc.read_h5ad("<user path>")
+ad.obs["split_random"] = du.get_random_split(
+    ad.obs, {"train": 0.8, "dev": 0.1, "test": 0.1}, random_state=42
+)
+ad.write_h5ad("<user path>")
+```
+
+This is the snippet from the repo README. It writes back in-place; make sure the user is OK with that, or copy the file first.
+
+**Stratified split** (preserves class balance across train/dev/test — better for imbalanced labels):
+
+Use `DatasetTransformer` with a `stratifying_label`:
+
+```python
+from bmfm_targets.datasets.dataset_transformer import DatasetTransformer
+
+dt = DatasetTransformer(
+    source_h5ad_file_name="<user path>",
+    split_weights={"train": 0.8, "dev": 0.1, "test": 0.1},
+    stratifying_label="celltype",  # or whichever column you want to stratify on
+    transforms=[],  # empty list = no gene transforms, just split creation
+    random_state=42,
+)
+processed = dt.process_datasets()
+processed.write_h5ad("<user path>")
+# Split column will be named split_stratified_celltype
+```
+
+Set `split_column_name=split_stratified_<label>` in the config.
+
+**User-named split**: if the user has their own split column (named anything), pass it via `split_column_name=<their_name>` at the CLI. No code needed.
+
+## Split strategy: prefer held-out-batch over random whenever possible
+
+Large pretrained RNA encoders absorb a lot of donor / batch / assay structure during pretraining. A random split at finetune time puts cells from the same donor in both train and eval — the model then "generalizes" by recognizing donor-specific tokens it has already seen, and the reported metric is not what the user thinks it is. This is most visible on CellXGene-derived data.
+
+Guidance when proposing a split:
+
+- If the user's h5ad has a grouping column — `donor_id`, `dataset_id`, `batch`, `assay`, `sample_id` — with **≥ 4 distinct values**, steer them towards a **held-out-group split**: hold one or more groups entirely out of train. Use `DatasetTransformer` with a group-aware strategy or write the column manually (pick ~80% of groups for train, split the rest into dev/test).
+- If the grouping column has only **2–3 values**, honestly tell the user the data is too narrow for a grouped split — one group in test means the test set is a single donor and the result is anecdotal. In that case random stratified is as good as it gets, but call out the limitation.
+- Only fall back to `split_random` when there's no grouping column at all, and say so in the summary you hand to the user.
+
+## Gotcha: label-name clash with a pretrained decoder
+
+A clash happens **if and only if** the user's `label_column_name` is identical to one already in the checkpoint's `label_columns`. When names match, state-dict loading pushes the pretrained head weights into the user's fresh head — if `n_unique_values` happens to match it loads silently with the wrong label-index semantics, and if it doesn't it fails with a shape mismatch. When the names differ, a fresh head is added and you don't need to do anything.
+
+Per-checkpoint head names (always re-check the provenance yaml; this is a snapshot):
+
+- **v1 BERT WCED multitask** (`biomed.rna.bert.110m.wced.multitask.v1`): `cell_type`, `tissue`, `tissue_general`, `donor_id`
+- **v2 Llama 32m MLM multitask**: `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`
+- **v2 Llama 47m WCED multitask**: `cell_type_ontology_term_id`, `tissue`, `tissue_general`, `donor_id`, `sex`
+- v1 MLM-RDA, v1 WCED (non-multitask), v1 MLM multitask have no label heads or different sets — read the yaml.
+
+If the user's column name matches one of those, rename it (`cell_type` → `my_cell_type`, `donor_id` → `my_donor_id`, …) in `ad.obs` before training, and point `label_column_name` at the new name. If it doesn't match, proceed — there is nothing to fix.
+
+There is no "close enough" — names either match exactly or they don't.
+
+## Gotcha: `expose_zeros: true` requires a zero-padding strategy
+
+`expose_zeros: true` on `dataset_kwargs` tells the data module to include non-expressed genes as zero-valued tokens. Pretraining the v2 checkpoints relies on this. But if you set it without also setting `pad_zero_expression_strategy`, every cell's input gets swamped by tens of thousands of zero tokens and the model learns to predict "zero" for everything.
+
+Always pair it with a strategy. The v2 checkpoints use `batch_wise` with `interleave_zero_ratio: 0.9` and `expressed_sample_ratio: 0.2`:
+
+```yaml
+data_module:
+  dataset_kwargs:
+    expose_zeros: true
+    pad_zero_expression_strategy: batch_wise
+    interleave_zero_ratio: 0.9
+    expressed_sample_ratio: 0.2
+```
+
+If you're unsure what the user needs, read the v2 checkpoint yaml and copy its values — those have been tuned. Do NOT set `expose_zeros: true` alone in any config you hand the user.
+
+## Inspecting a DNA csv directory
+
+For DNA finetuning the user needs `<dir>/{train,test,dev}.csv`. Check:
+
+```bash
+ls <dir>
+head -3 <dir>/train.csv
+wc -l <dir>/*.csv
+```
+
+Then in Python:
+
+```python
+import pandas as pd
+df = pd.read_csv("<dir>/train.csv")
+print(df.head())
+print(df.dtypes)
+print("num rows:", len(df))
+print("label columns (all but first, which is the sequence):")
+for c in df.columns[1:]:
+    if df[c].dtype.kind in "fi":
+        kind = "regression" if df[c].dtype.kind == "f" else "classification"
+    else:
+        kind = "classification"
+    print(f"  {c}: {kind} ({df[c].nunique()} unique, dtype={df[c].dtype})")
+```
+
+Rules for the csv format:
+
+- **Column 0 MUST be the sequence** (A/C/G/T string). The framework reads it positionally.
+- **Label columns follow**, named however the user wants — they get referenced by name in `label_columns` in the yaml.
+- Trailing columns (e.g. `seq_id`) are fine — they just get ignored.
+- All three files (`train.csv`, `test.csv`, `dev.csv`) must have the same columns.
+
+## Gene identifier mismatch
+
+If the h5ad has Ensembl ids (`ENSG...`) but the tokenizer is gene-symbol-based (the default for scRNA), the framework applies a mapping transform — it's already enabled by default in most data_modules via `RenameGenesTransform` (see `bmfm_targets/datasets/dataset_transformer.py`). If the user has custom identifiers (e.g. organism other than human), they'll need to provide their own gene map; flag this early rather than silently producing low-quality embeddings.
+
+## Labels file (`labels.json`)
+
+For `predict` and `finetune` the framework writes `<working_dir>/labels.json` listing the label set seen during training. On a second run pointing at the same `working_dir`, it reuses this file — useful for consistent label ordering across runs, but a source of confusion when the user changes label columns and forgets to clear the working_dir. When in doubt, delete `labels.json` or pick a fresh `working_dir`.
+
+## Working directory guidance
+
+- If the user provides `working_dir`, use it.
+- Otherwise default to `./outputs/<task_class>_<timestamp>/` in the current repo.
+- Avoid `/tmp` for anything the user will want to inspect later — macOS clears `/tmp` on reboot.
+- The directory will be created if it doesn't exist; existing contents (especially `labels.json`) get reused, which is both a feature and a foot-gun.

--- a/.claude/skills/bmfm-targets-run/references/fields_tokenizer.md
+++ b/.claude/skills/bmfm-targets-run/references/fields_tokenizer.md
@@ -1,0 +1,213 @@
+# Fields, tokenizers, and deep pretraining lore
+
+Most users will not touch any of this. It's here for two audiences: users doing genuinely custom pretraining, and Claude when it needs to translate a published checkpoint's fields block into a fine-tuning config (because these fields must be copied **exactly** to avoid silent misloads).
+
+## The field/tokenizer/loss triangle
+
+A BMFM config has three coupled pieces:
+
+- **`fields:`** — list of `FieldInfo` objects. Each field is a data stream into the model (genes, expressions, sometimes `label_expressions`). Each field declares how it's tokenized and whether it gets masked.
+- **`tokenizer:`** — a `TokenizerConfig` naming the vocab (`all_genes`, `gene2vec`, `protein_coding`, `snp`, etc.).
+- **`trainer.losses:`** — what objective computes gradient against which field output head.
+
+These three have to be consistent. A loss entry with `field_name: expressions` only works if the expressions field has a `decode_modes` that exposes the right head.
+
+## Expression field encoders
+
+The expressions field is where most of the complexity lives. The encoder choice tells the model how to map a real-valued expression count into a token representation.
+
+- **`mlp_with_special_token_embedding`** — small MLP on the scalar value + a learned zero token. Used by v1 WCED and v1 MLM multitask.
+- **`scale_adapt`** — scale-adaptive sinusoidal encoding with `n_sin_basis` components. Used by v1 RDA and all v2 (llama) multitask checkpoints. Handles wide value ranges more robustly.
+- **`continuous_value_encoder`** — the base `tokenization_strategy`; the `encoder_kwargs.kind` specifies which flavor.
+
+Key `encoder_kwargs`:
+
+- `zero_as_special_token: true` — treats 0-expression as a dedicated token, not as "value zero". Recommended.
+- `n_sin_basis`, `basis_scale`, `trainable` — scale_adapt-specific; copy from the checkpoint's training yaml exactly.
+
+## Decode modes
+
+`decode_modes` on a field tells the model what output heads to attach:
+
+- `token_scores` — per-token classification over the field's vocab. Used for MLM-style masked token prediction on the `genes` field.
+- `regression` — scalar regression head per token.
+- `is_zero` — binary head predicting whether the value is zero.
+- `wced: {vocab_field: genes, logit_outputs: [mse, is_zero_bce]}` — the WCED decoder. Attaches a shallow decoder that projects from CLS to vocab-sized MSE + is-zero BCE heads. The `vocab_field` tells the WCED decoder which field's vocab to target.
+
+A field can have multiple decode modes simultaneously. Example from MLM+RDA:
+
+```yaml
+- _target_: bmfm_targets.config.FieldInfo
+  field_name: expressions
+  is_masked: true
+  tokenization_strategy: continuous_value_encoder
+  encoder_kwargs:
+    kind: scale_adapt
+    n_sin_basis: 48
+    basis_scale: 1.5
+    trainable: true
+    zero_as_special_token: true
+  decode_modes:
+    - regression
+    - is_zero
+```
+
+This exposes both a regression and an is_zero head; `trainer.losses` then has `mse` + `is_zero_bce` entries, each with `field_name: expressions`.
+
+## WCED-specific: `wced_target`
+
+When `decode_modes.wced` is set, the WCED decoder produces predictions for **all** genes in the vocab from the CLS embedding, regardless of which genes were in the input. The `wced_target` on the loss entry selects which subset to supervise:
+
+- `wced_target: input_genes` — only genes that were in the cell's input tokens. Smaller signal, higher fidelity.
+- `wced_target: non_input_genes` — genes NOT in the input (i.e. reconstruct-what-you-didn't-see). The meat of WCED.
+- No `wced_target:` — all genes.
+
+The v1 WCED multitask yaml has four loss entries for this — `mse` + `is_zero_bce` for both `input_genes` and `non_input_genes` — with equal weight. The non_input_genes pair is the autoencoder-like "reconstruct cells from a partial view" objective.
+
+## Multiple CLS tokens: `prepend_tokens` and `decode_from`
+
+The `[CLS]` token at position 0 is the default "summary" embedding most models decode classification heads from. For multitask models it can be useful to give each task its own dedicated CLS position — this prevents the heads from fighting over a single summary and lets the model specialize different positions to different tasks. BMFM supports this via two coupled settings: `prepend_tokens` on the tokenizer, and `decode_from` on each `LabelColumnInfo`.
+
+**`tokenizer.prepend_tokens`** — an ordered list of special tokens prepended to every sequence. If unset, the default is just `[CLS]` at position 0. When set, every sequence starts with exactly these tokens in this order; positions 0, 1, 2, … correspond to list indices 0, 1, 2, …. The tokens must already exist in the tokenizer's special-token vocab.
+
+**`LabelColumnInfo.decode_from`** — an integer position index into `prepend_tokens`. The classification head for that label reads from the hidden state at that position. If `decode_from` is `None` (default), the head reads from the model's pooled output.
+
+Example from `run/checkpoints/biomed.rna.llama.47m.wced.multitask.v1.yaml`:
+
+```yaml
+tokenizer:
+  identifier: protein_coding
+  prepend_tokens: ['[CLS]', '[CLS_0]', '[CLS_1]', '[CLS_2]', '[CLS_3]']
+label_columns:
+  - label_column_name: cell_type_ontology_term_id
+    decode_from: 1          # reads [CLS_0]
+  - label_column_name: tissue
+    decode_from: 2          # reads [CLS_1]
+  - label_column_name: tissue_general
+    decode_from: 2          # shares [CLS_1] with tissue
+  - label_column_name: donor_id
+    decode_from: 3          # reads [CLS_2]
+  - label_column_name: sex
+    decode_from: 4          # reads [CLS_3]
+```
+
+Position 0 (`[CLS]`) is reserved for the WCED decoder here.
+
+### Implications for downstream users
+
+1. **Leave the tokenizer alone when fine-tuning from a multi-CLS checkpoint.** The checkpoint's pretrained hidden states at positions 1..N encode task-specific summaries; swapping to a plain `[CLS]`-only tokenizer destroys this. If the user does not explicitly set `tokenizer:` in their finetune yaml, the framework loads the tokenizer shipped with the checkpoint — which is what you want.
+
+2. **Choose `decode_from` intelligently when adding a new fine-tune head.** You have three reasonable options, in order of preference:
+   - Re-use the CLS position whose pretraining task is closest to yours (e.g. for a new cell-type classifier on the WCED checkpoint, `decode_from: 1` — the CLS that already learned cell-type summaries).
+   - Use a "fresh" CLS position not bound to any pretraining task (if the checkpoint has spare prepend_tokens), to avoid interference.
+   - Omit `decode_from` entirely and use the pooled output — simplest, but ignores the per-task CLS specialization the checkpoint invested in.
+   Prompt the user explicitly to make this call rather than guessing.
+
+3. **If `prepend_tokens` is unset on a checkpoint (e.g. the 32m MLM multitask),** there is only `[CLS]` at position 0 and no `decode_from` on the label columns — all heads share the pooled output. Leave it that way.
+
+## WCED masking requires both a WCEDMasker AND matching WCED losses
+
+WCED (Whole Cell Expression Decoder) pretraining is not enabled by a single switch. It requires both:
+
+1. A `WCEDMasker` installed as the data_module's masking strategy:
+   ```yaml
+   data_module:
+     masking_strategy:
+       _target_: bmfm_targets.training.masking.strategy.WCEDMasker
+       _partial_: true
+   ```
+   The masker constructs three label sets per batch — `input` (genes present in the input tokens), `non_input` (genes absent from the input), and `all` — which are the prediction targets.
+
+2. Loss entries with `field_name: expressions` and `wced_target:` on the expressions field's WCED decode head:
+   ```yaml
+   trainer:
+     losses:
+       - field_name: expressions
+         name: mse
+         ignore_zero: true
+         wced_target: non_input_genes   # or input_genes, or all_genes
+       - field_name: expressions
+         name: is_zero_bce
+         wced_target: non_input_genes
+   ```
+   The expressions field must have `decode_modes.wced: {vocab_field: genes, logit_outputs: [mse, is_zero_bce]}` set so the WCED decoder head exists to be supervised.
+
+Omit either side and WCED does nothing: masker without losses trains no decoder; losses without masker fail because the `input/non_input/all` label tensors aren't populated.
+
+**The choice of `wced_target` (`input_genes`, `non_input_genes`, `all_genes`) is the user's.** They encode different objectives:
+
+- `input_genes` — "reproduce what I told you." Easier signal, less useful alone.
+- `non_input_genes` — "reconstruct what I hid from you." The cell-level autoencoder flavor; this is the interesting WCED signal.
+- `all_genes` — "reconstruct the whole cell." Combines both; this is what the v2 47m llama uses with weight 1.0.
+
+The v1 BERT WCED multitask yaml uses both `input_genes` and `non_input_genes` at weight 1.0 and omits `all_genes`. The v2 llama WCED uses `all_genes` at weight 1.0 and keeps `input_genes` / `non_input_genes` at weight 0.0 (head compatibility). Either pattern is legitimate; match the checkpoint's when extending.
+
+## A label loss REQUIRES the label in `label_columns`
+
+A frequent failure mode: user adds a `trainer.losses` entry like
+```yaml
+- label_column_name: my_new_label
+  name: cross_entropy
+```
+but forgets to add a matching `LabelColumnInfo` in `label_columns`. The framework won't silently infer it — instantiation fails because no classification head is created for `my_new_label`. **Every loss with `label_column_name:` must have a `LabelColumnInfo` entry with the same name**, and that entry drives the head shape (`n_unique_values`, `is_regression_label`, `classifier_depth`, `decode_from`, `gradient_reversal_coefficient`). Add the `LabelColumnInfo` first; the loss entry just binds an objective to it.
+
+## Tokenizer identifiers
+
+Set `tokenizer.identifier` to one of:
+
+- `all_genes` — ~60k genes, the default for most RNA pretraining.
+- `all_genes_v2` — newer version of `all_genes` with different gene coverage.
+- `protein_coding` — ~19k protein-coding genes. Used for finetuning when `data_module.limit_genes: protein_coding` is set.
+- `gene2vec` — gene embeddings from the gene2vec paper.
+- `snp` — DNA SNP tokenizer.
+
+Vocab files live under `bmfm_targets/tokenization/<identifier>_vocab/`. The identifier must match what the checkpoint was pretrained with — using a different vocab means the model's embedding table is indexed wrong and you'll get garbage outputs.
+
+## Gradient reversal (`gradient_reversal_coefficient`)
+
+Set on a `LabelColumnInfo`:
+
+```yaml
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: donor_id
+    gradient_reversal_coefficient: 3.0
+```
+
+This flips the sign of gradients flowing back from this label's loss head during training — pushing the encoder to make representations *less* predictive of `donor_id`. Pair with a matching `trainer.losses` entry (usually `focal` or `cross_entropy`) with a small weight.
+
+The `silent_label_values:` field (e.g. `- unknown`) tells the framework to not compute the loss when the label equals one of these — useful when the label is missing or uninformative for a subset of samples.
+
+## Custom pretraining: when you really need to touch this
+
+If the user is pretraining from scratch (no checkpoint), the fields/tokenizer block is a design choice. Rough guidance:
+
+- **Standard MLM pretraining**: `genes` field with `is_masked: true, decode_modes: [token_scores]` + `expressions` field with `is_masked: true, decode_modes: [regression, is_zero]`. Losses: `cross_entropy` on genes, `mse` + `is_zero_bce` on expressions. Starting point: `run/mlm_train_config.yaml`.
+- **WCED pretraining**: `genes` field unmasked + `expressions` field with `decode_modes.wced`, `WCEDMasker` as masking strategy. Losses: 4-entry block (mse × 2 + is_zero_bce × 2) on input_genes / non_input_genes. Starting point: `run/checkpoints/biomed.rna.bert.110m.wced.v1.yaml`.
+- **RDA**: add `rda_transform` to the data_module, use `scale_adapt` encoder, set `log_normalize_transform: false` (RDA works on raw counts). Starting point: `run/rda_mlm.yaml` or `run/checkpoints/biomed.rna.bert.110m.mlm.rda.v1.yaml`.
+- **Multitask**: layer classification heads on top of the reconstruction losses via `label_columns` + matching `trainer.losses` entries with label names. Starting point: `run/multitask_train_config.yaml`.
+
+**Don't design a custom pretraining config from scratch.** Copy a checkpoint's provenance yaml and mutate it. The coupling between fields / tokenizer / masker / losses is load-bearing; silent misspecification will train a model that converges but has poor representations.
+
+## `expose_zeros` + `pad_zero_expression_strategy` — never one without the other
+
+For pretraining (and especially WCED), cells need some non-expressed genes in the input so the model learns to discriminate "truly zero" from "not observed". Set that via `data_module.dataset_kwargs.expose_zeros: true`.
+
+But zero-expressed genes outnumber expressed ones by 10–100×. If you turn on `expose_zeros` and stop there, the input sequence is mostly zeros and the model learns to predict zero everywhere. You MUST also configure `pad_zero_expression_strategy` so the framework subsamples zeros down to a useful ratio:
+
+```yaml
+data_module:
+  dataset_kwargs:
+    expose_zeros: true
+    pad_zero_expression_strategy: batch_wise   # the v2 default
+    interleave_zero_ratio: 0.9                 # fraction of zeros vs nonzeros per sample
+    expressed_sample_ratio: 0.2                # fraction of the *expressed* genes to keep
+```
+
+`batch_wise` is what the v2 Llama pretraining recipes use; other strategies exist (read `bmfm_targets/datasets/base_rna_expression/` for the full list). If you're unsure, copy the values from the v2 checkpoint yamls — they're tuned. **Do NOT emit `expose_zeros: true` without a matching strategy in any yaml you hand the user.**
+
+## When this file is NOT needed
+
+- Fine-tuning from an existing checkpoint: copy the fields/tokenizer block from the checkpoint's provenance yaml; don't re-derive.
+- Prediction: the checkpoint's own config is loaded by the framework; you only override data_module paths.
+- DNA tasks: DNA fields are simpler (a single `dna_sequence` field); see `run/dna_predict.yaml` for the pattern.

--- a/.claude/skills/bmfm-targets-run/references/interpret.md
+++ b/.claude/skills/bmfm-targets-run/references/interpret.md
@@ -1,0 +1,109 @@
+# Interpret: Captum-based attribution
+
+Interpret runs Captum Layer Integrated Gradients over a trained checkpoint to produce per-gene importance scores for each sample, per label of interest. It uses `InterpretTaskConfig` (not `TrainingTaskConfig` or `PredictTaskConfig`) — same entry point, different task type.
+
+## Minimum viable config
+
+When `checkpoint=` is set the model, tokenizer, and fields are all rehydrated from the checkpoint. Don't put `model:`, `tokenizer:`, or `fields:` blocks in the interpret yaml — they'll either be ignored or silently conflict with what the checkpoint actually needs.
+
+Adapt `examples/interpret_from_checkpoint.yaml`:
+
+```yaml
+defaults:
+  - _self_
+
+data_module:
+  _target_: bmfm_targets.datasets.base_rna_expression.BaseRNAExpressionDataModule
+  _partial_: true
+  max_length: 2048         # must be <= the checkpoint's training max_length
+  limit_dataset_samples: 200  # attribution is slow; cap the sample count
+  batch_size: 1            # attribution is forced to bs=1 anyway
+  num_workers: 4
+  dataset_kwargs:
+    processed_data_source: ${input_file}
+    split_column_name: ${split_column_name}
+
+label_columns:
+  - _target_: bmfm_targets.config.LabelColumnInfo
+    label_column_name: ${label_column_name}
+    is_regression_label: false
+
+task:
+  _target_: bmfm_targets.config.InterpretTaskConfig
+  default_root_dir: ${working_dir}
+  accelerator: gpu
+  precision: 16-mixed
+  tf32_mode: medium
+  attribute_kwargs:
+    n_steps: 50            # Integrated Gradients steps; 20–100 typical
+  attribute_filter:
+    ${label_column_name}: [<class_a>, <class_b>]   # which labels to attribute toward
+  checkpoint: ${checkpoint}
+
+input_file: null
+working_dir: /tmp/interpret_run
+checkpoint: null
+label_column_name: null
+split_column_name: split_random
+```
+
+## `attribute_filter` is load-bearing
+
+Without `attribute_filter`, the attribution module runs Integrated Gradients for **every** class in the label dict — on a 200-class cell-type model that is ~200× slower than necessary and the resulting output is unreadable. The user almost always wants attribution toward a handful of classes (e.g. "which genes make this cell look like a T cell?").
+
+`attribute_filter` is a dict keyed by label column name, where each value is a list of label values to attribute toward:
+
+```yaml
+task:
+  attribute_filter:
+    cell_type: ["T cell", "B cell", "NK cell"]
+    # unlisted columns fall back to "all classes"
+```
+
+At runtime the code merges your `attribute_filter` with the full class set; only the listed classes get per-sample IG. Always propose a small list to the user, even if they say "all of them" — usually they actually mean 3–5.
+
+## Post-processing: `get_mean_attributions`
+
+Raw output is one attribution vector per (sample, label-column, label) triple. Users almost always want the aggregate: "which genes are consistently important for class X across all cells of class X?". Use `bmfm_targets.evaluation.interpret.get_mean_attributions` for that:
+
+```python
+from bmfm_targets.evaluation.interpret import get_mean_attributions, join_sample_attributions
+import pandas as pd
+
+# After the run completes, load the per-sample attributions (format depends on run output)
+# — see bmfm_targets/evaluation/interpret.py for join_sample_attributions usage.
+attribution_df = join_sample_attributions(...)    # genes × samples
+
+mean_attr = get_mean_attributions(attribution_df, alpha=0.05, significance_attr=0.1)
+# mean_attr has columns: attribution, p_value, -log2p, highlight
+# highlight = True where p < Bonferroni(alpha) and |attribution| > significance_attr
+top = mean_attr.query("highlight").sort_values("attribution", ascending=False).head(30)
+```
+
+This is the canonical "top genes" view. The `highlight` column filters to genes that are both statistically significant (one-sample t-test against 0 with Bonferroni correction) and have a meaningful effect size.
+
+Point the user at this function rather than letting them eyeball raw attributions — the p-value / effect-size combination is what makes the list interpretable.
+
+## What gets produced
+
+Under `working_dir/` the run writes per-sample `SampleAttribution` records (gene × score tuples, per label-column-per-label). Exact file layout depends on the task version — inspect `bmfm_targets/evaluation/interpret.py` if the user needs the schema.
+
+## Gotchas
+
+- **Don't hardcode model / tokenizer / fields.** With `checkpoint=` set, all three are loaded from the checkpoint. Putting them in the yaml is at best noise, at worst a silent mismatch.
+- **`max_length` must be ≤ the checkpoint's training value** (the positional embedding table isn't extendable).
+- **Labels must match** the pretrained head's label vocab, OR the checkpoint must have been fine-tuned on the user's label set. Attributing toward an unseen class returns garbage.
+- **It's slow.** Budget roughly `n_samples × n_filter_classes × n_steps` forward/backward passes. A few hundred samples × 3–5 classes × 50 steps is fine on a single GPU; full-dataset × all-classes is not.
+- **GPU memory.** Batch is forced to 1, but `n_steps=50` holds 50 forward graphs. Drop `n_steps` to 20 if you OOM.
+- **`.ckpt` file on disk vs HuggingFace id.** Interpret needs the full Lightning checkpoint; if the user only has an HF id, they need to either download + extract to `.ckpt` or fine-tune first and point at the resulting `.ckpt`.
+
+## When the user says "show me which genes matter"
+
+Flow:
+
+1. Confirm they have a local `.ckpt` file (not just a HuggingFace id).
+2. Confirm they have a data subset (100–500 samples is typical).
+3. Confirm the **specific classes** to attribute toward — push back if they say "all of them"; pick 3–5.
+4. Write the config from `examples/interpret_from_checkpoint.yaml` — no model/tokenizer/fields blocks, with `attribute_filter` set.
+5. Dry-run, then run. Warn about runtime.
+6. Hand them the `get_mean_attributions` snippet for post-processing; tell them to look at the `highlight` column for the interpretable top-gene list.

--- a/.claude/skills/bmfm-targets-run/references/losses.md
+++ b/.claude/skills/bmfm-targets-run/references/losses.md
@@ -1,0 +1,83 @@
+# Loss selection
+
+Loss choice is where users get the most confused — the loss system is composition-based (`DataSource` × `Objective`), with many combinations legal. Most users shouldn't touch it. This file explains how to pick, when to deviate, and why.
+
+## The governing principle
+
+**The checkpoint's own losses are your default.** Not because they're always right for your downstream task, but because they encode the shape of the model's output heads. A loss block that doesn't match the model's heads will either fail instantiation or silently train garbage.
+
+For fine-tuning, you usually replace the pretraining losses with task-appropriate losses — that's fine, the heads for new `LabelColumnInfo` entries are created as needed. But for `predict` and `interpret` (no loss involved) and for pretraining-continuation, the checkpoint's own block is the starting point.
+
+## Every label loss requires a matching `LabelColumnInfo`
+
+A `trainer.losses` entry with `label_column_name: foo` by itself does nothing — it binds an objective, but the classification head is built from the matching `LabelColumnInfo` entry in `label_columns`. If there is no `label_columns` entry with `label_column_name: foo`, no head is created and instantiation fails. When you add a fine-tuning loss on a new column, add the `LabelColumnInfo` first and define its shape there (`is_regression_label`, `n_unique_values`, `classifier_depth`, `decode_from`, `gradient_reversal_coefficient`, `silent_label_values`). The loss entry only picks the objective (cross_entropy, focal, mse, …) and optional weight.
+
+This is the same direction for `field_name:` losses on expressions/genes — the head is created from the field's `decode_modes`; the loss picks an objective for a head that already exists.
+
+## Problem type → default
+
+This table is what `run/finetune.yaml` already documents in a comment; expanded here with reasoning.
+
+| Problem | Default `name:` | When to use |
+| --- | --- | --- |
+| Multi-class classification (balanced) | `cross_entropy` | The baseline. Always safe. |
+| Multi-class classification (imbalanced) | `focal` with `focal_gamma: 2` | When one class has >5× more examples than another, or when rare-class recall matters. The v1 multitask checkpoints use this on tissue / donor_id. |
+| Binary classification (2-class categorical) | `cross_entropy` | Fine — it degenerates to 2-class softmax. |
+| Binary classification (single float label) | `bce_with_logits` | When the label is already a float in [0, 1] — e.g. a probability target. |
+| K independent binary labels (multi-label) | `bce_with_logits` | One head outputs K logits; each is an independent binary decision. |
+| Regression (single target) | `mse` | Standard MSE. |
+| Regression (zero-inflated, e.g. expression) | `mse` with `ignore_zero: true` + paired `is_zero_bce` | Decompose into "is it zero?" (BCE) and "given it's nonzero, how much?" (MSE on nonzeros). This is what WCED does for expression reconstruction. |
+| CellXGene cell type ontology labels | `hce` (Hierarchical Cross-Entropy) | **Only** for `cell_type_ontology_term_id` backed by Cell Ontology (`label_ontology: celltypeont`). This is effectively the single HCE use case wired into the codebase today — see the HCE section in `SKILL.md`. For all other "cell type" columns or custom hierarchies, use `cross_entropy` or `focal`. |
+| Adversarial de-biasing (remove nuisance signal) | same loss as above + `gradient_reversal_coefficient` on the `LabelColumnInfo` | The classic example: train to remove donor/batch effects. See the section below. |
+
+## Objective catalog (from `bmfm_targets.training.losses.objectives`)
+
+Available `name:` values in `trainer.losses`:
+
+- `cross_entropy` — `CrossEntropyObjective`. Standard classification.
+- `focal` — `FocalObjective`. Takes `focal_gamma` (default 2).
+- `hce` — `HCEObjective`. Hierarchical cross-entropy; requires an ontology label with roll-up.
+- `mse` — `MSEObjective`. Takes `ignore_zero: true|false`.
+- `mae` — `MAEObjective`. Less common; use if you specifically want L1.
+- `bce_with_logits` — `BCEWithLogitsObjective`. For binary / multi-label float targets.
+- `is_zero_bce` — `IsZeroBCEObjective`. Binary "is this expression value zero?" — pairs with `mse` + `ignore_zero: true` for zero-inflated regression.
+- `is_zero_focal` — `IsZeroFocalObjective`. Focal variant of is_zero_bce.
+- `token_value` — `TokenValueObjective`. Specialized for scRNA expression tokens; see `fields_tokenizer.md`.
+
+The `DataSource` side is implicit — it's picked from whether the loss entry has `label_column_name:` (→ `LabelSource`), `field_name:` (→ `FieldSource`), or `field_name:` + `wced_target:` (→ `WCEDFieldSource`). You don't configure this directly.
+
+## Gradient reversal (adversarial de-biasing)
+
+Used to strip out nuisance information from the model's representations — e.g. making the model work well for cell-type classification while being actively *bad* at predicting donor_id.
+
+**How it works in BMFM:** set `gradient_reversal_coefficient` on the `LabelColumnInfo` you want to *remove*. Add a matching `trainer.losses` entry with that label's name and an appropriate loss (usually `focal` or `cross_entropy`). During training the gradient flowing back from that loss head gets flipped, pushing the encoder to make the representation *less* predictive of that label.
+
+Canonical reference: `run/checkpoints/biomed.rna.bert.110m.wced.multitask.v1.yaml`, where `donor_id` has `gradient_reversal_coefficient: 3.0` and a focal loss with `weight: 0.05`. The small loss weight + high GRL coefficient is deliberate — you want the signal to flow back aggressively but not dominate the primary loss.
+
+For fine-tuning: same pattern. Add the nuisance column as a `LabelColumnInfo` with a GRL coefficient, add a matching loss entry, and keep the weight small relative to your primary task loss.
+
+## Loss weights
+
+When you have multiple losses (multitask finetuning, or WCED-style pretraining), explicit `weight:` values matter. Guidance:
+
+- Unweighted entries default to weight 1.0.
+- The primary task loss should dominate; auxiliary / nuisance losses should typically be 0.05 – 0.2.
+- For WCED pretraining, the expression reconstruction losses (`mse` + `is_zero_bce`) each carry weight 1.0 by convention — see the wced.v1 and wced.multitask.v1 yamls. When you have both `input_genes` and `non_input_genes` WCED targets, all four entries usually have weight 1.0.
+
+## When to deviate from the checkpoint
+
+Deviate only when the downstream task genuinely requires it:
+
+- The checkpoint pretrains on expressions (MSE + is_zero_bce); you fine-tune on a classification label → you add a `cross_entropy` entry for your new label column and drop the expression losses (or keep them as auxiliary at low weight if you want to retain reconstruction capability — rare).
+- The checkpoint uses `focal` for an imbalanced column; your data isn't imbalanced → still fine to use `cross_entropy`, but you'll inherit the checkpoint's head init; `focal` is a fine-tuning default in the package for multitask head reuse.
+- The checkpoint's loss block has multitask heads for `tissue`, `donor_id`, etc.; your data doesn't have those columns → drop those entries. Don't leave them pointing at missing columns; Hydra will fail at runtime, not at config-load.
+
+**Always note the deviation in a comment** at the top of the generated yaml so the user understands what changed from the checkpoint's provenance and why.
+
+## What NOT to do
+
+- Don't mix a regression target with `cross_entropy` thinking it'll "just work" — it won't; the head shape is wrong.
+- Don't add a WCED loss (`wced_target: ...`) to a checkpoint whose expressions field doesn't have `decode_modes.wced` set. The head doesn't exist.
+- Don't add WCED losses without installing `WCEDMasker` as the data_module's `masking_strategy` (and vice versa) **when you are pretraining with WCED**. In a pretraining recipe WCED needs both — the masker builds the `input_genes` / `non_input_genes` / `all_genes` label tensors and the losses consume them. One without the other is a silent no-op or an instantiation failure. **This coupling only applies during WCED pretraining.** Once a WCED checkpoint is trained, it can be used like any other encoder — finetune or predict with it without WCED losses and without `WCEDMasker`; the pretrained head is discarded / ignored in those modes. See `references/fields_tokenizer.md`.
+- Don't stack `mse` + `is_zero_bce` with `ignore_zero: false` on both — you'll double-count zeros.
+- Don't use `focal` on a balanced binary problem; it costs you calibration for no gain.

--- a/.claude/skills/bmfm-targets-run/references/overrides.md
+++ b/.claude/skills/bmfm-targets-run/references/overrides.md
@@ -1,0 +1,138 @@
+# Hydra overrides, CLI flags, and common errors
+
+## CLI anatomy
+
+```
+bmfm-targets-run [-cd <config_dir>] -cn <config_name> [key=value ...] [++key=value ...] [~key]
+```
+
+- `-cd` / `--config-dir`: where Hydra looks for configs. **If invoking from the biomed-multi-omic repo root, use `-cd run`**; otherwise pass `--config-dir <abs path>/run`. The entry point's default `config_path` is the directory of `scbert_main.py`, which is NOT where users want to look.
+- `-cn` / `--config-name`: the `.yaml` filename (no extension) to load as the top config. E.g. `predict`, `finetune`, `rda_mlm`, `mlm_train_config`, `multitask_train_config`, `dna_predict`, `dna_finetune_train_and_test_config`.
+- `key=value`: override a field that already exists in the resolved config. Fails if the field is not present.
+- `++key=value`: add-or-override. Use this when the field may not be in the base config (e.g. `++data_module.rda_transform=auto_align` against a config that doesn't already set it).
+- `~key`: remove a field entirely. Useful for `~model` in predict scenarios where you want everything loaded from the checkpoint instead.
+
+## The three flavors of override
+
+| Syntax | Behavior | When to use |
+| --- | --- | --- |
+| `key=value` | Replace existing field; error if missing | Known fields in the base config |
+| `++key=value` | Add if missing, replace if present | Optional fields (e.g. `rda_transform`) |
+| `+key=value` | Add if missing, error if present | Rare; avoid |
+| `~key` | Remove field | Ask model to reload structure from checkpoint |
+
+## Dotted paths
+
+Hydra uses dots for nested fields: `data_module.max_length=4096`, `task.accelerator=cpu`, `trainer.learning_rate=1e-5`. Lists are indexed: `label_columns[0].label_column_name=my_col`. For lists, overriding via index can be fragile — prefer editing the yaml.
+
+## Interpolation (`${...}`)
+
+Values can reference other config fields: `working_dir: ${oc.env:BMFM_TARGETS_TRAINING_DIR}/my_run` — this reads the env var `BMFM_TARGETS_TRAINING_DIR`. If the env var is unset and there's no default, it errors at resolution time, not config-load time. The dry-run (`--cfg job --resolve`) catches this.
+
+Common pitfalls:
+
+- `${var}` without the `oc.env:` prefix references another config field, not an env var. `${working_dir}` means "look up `working_dir` elsewhere in the config".
+- Circular interpolation silently causes resolution failure. Don't set `a: ${b}` and `b: ${a}`.
+
+## `-cd run` vs `--config-dir`
+
+`-cd run` is a relative path, evaluated from the current working directory. It only works if you're running from the repo root (or any directory that has a `run/` subdirectory). From a different CWD, pass an absolute path:
+
+```bash
+bmfm-targets-run --config-dir /abs/path/to/biomed-multi-omic/run -cn predict ...
+```
+
+If the user pip-installed and doesn't have `run/`, the skill falls back to its bundled `examples/`:
+
+```bash
+bmfm-targets-run --config-dir /abs/path/to/skill/examples -cn predict_template ...
+```
+
+## Config composition (defaults list)
+
+Top-level configs compose from smaller configs via a `defaults:` block at the top:
+
+```yaml
+defaults:
+  - data_module: base_seq_cls
+  - task: train_and_test
+  - trainer: default
+  - _self_
+```
+
+This pulls `run/data_module/base_seq_cls.yaml`, `run/task/train_and_test.yaml`, `run/trainer/default.yaml`, merges them, and then merges `_self_` (the current file) on top. To override a default at the CLI, use `data_module=some_other_group`.
+
+## Common errors and fixes
+
+### `Error instantiating '...': missing 1 required positional argument: losses`
+
+The dataclass has a required field that wasn't set. Usually means `trainer.losses` is absent. Add a minimal `trainer.losses` block:
+
+```yaml
+trainer:
+  losses:
+    - label_column_name: my_label
+      name: cross_entropy
+```
+
+### `Key '...' is not in struct`
+
+You used `key=value` for a field that doesn't exist in the base config. Switch to `++key=value`.
+
+### `InterpolationKeyError: Interpolation key 'X' not found`
+
+A `${X}` reference can't resolve. Either the field `X` isn't in the config, or for `${oc.env:X}` the env var isn't set. Check the full error — it tells you where the reference came from.
+
+### `Could not find 'predict'`
+
+Hydra can't find the named config. Either you forgot `-cd run`, your CWD is wrong, or the config name has a typo. `ls run/*.yaml` to check.
+
+### `ValidationError: Invalid type assigned`
+
+The yaml's value doesn't match the dataclass's type. For example `max_length: "4096"` (string) vs `max_length: 4096` (int). OmegaConf is strict.
+
+### `_partial_` confusion
+
+Many BMFM data_modules and models use `_partial_: true`, which means "instantiate later with these kwargs, don't fully construct now". If you see errors about missing required args to a data_module, it's likely because `_partial_` got dropped somewhere. Restore it.
+
+### Dry-run catches all of these
+
+```bash
+bmfm-targets-run -cd run -cn <your_config> --cfg job --resolve <your overrides>
+```
+
+This renders the fully-resolved config without running training. Every one of the above errors shows up here.
+
+## Knobs that matter
+
+A short list of the most-asked-about overrides:
+
+- `data_module.max_length` — token sequence length. Pretraining ceiling = checkpoint's training value (typically 1024 or 4096 for v1, 8192 for v2). Can be smaller at inference/fine-tuning. If you need longer, you'll need to re-pretrain.
+- `data_module.rda_transform` — only applies when using RDA-trained checkpoints or when pretraining with RDA. Five accepted values, each a distinct policy:
+  - `"downsample"` — random downsample to match pretraining counts. Data augmentation flavor; what the v1 RDA checkpoint was trained with.
+  - `"poisson_downsample"` — Poisson-noise downsample. Stronger augmentation; pairs with `renoise:` in some pretraining recipes.
+  - `"auto_align"` — at collate time, pick the max-counts cell in the dataset and align every sample's target-reads T to that value. Recommended for **inference / zero-shot prediction**, not for training (per the docstring at `bmfm_targets/training/data_module.py:199`). Requires the dataset to implement `.max_counts()` (CellXGene SOMA and litdata paths do).
+  - `"equal"` — set source reads S equal to target reads T; prepares inputs in RDA style without upsampling. Useful for encoder-only feature extraction when you don't want augmentation.
+  - integer (e.g. `10000`) — hard-code T to a specific value. Reproducible across runs and datasets.
+  - `null` / omitted — no RDA transform.
+  All RDA modes log-normalize internally, so set `data_module.log_normalize_transform: false` when any RDA mode is on (the framework warns and disables the standalone log_normalize automatically, but the explicit setting is cleaner).
+- `data_module.log_normalize_transform` — `true` if the checkpoint expects log-normalized input (this is the norm for every non-RDA published checkpoint); `false` for RDA checkpoints (RDA normalizes internally) or when the h5ad is *already* log-normalized upstream. Raw-count input data with this set to `false` and no RDA will give garbage — see `references/checkpoints.md` for the full story.
+- `data_module.limit_genes` — `null` (all genes), `protein_coding` (~19k genes; recommended for matching pretraining corpora), or `tokenizer` (genes known to the tokenizer).
+- `data_module.num_workers` — 0 for debugging / CPU, 8+ for GPU training.
+- `task.accelerator` — `gpu` (default) or `cpu` (for CI / debugging).
+- `task.precision` — `16-mixed` (default for GPU) or `32` (for CPU / debugging).
+- `task.max_epochs` / `task.max_steps` — set `max_steps=5` for smoke tests.
+- `task.val_check_interval` — `null` disables mid-epoch validation; integer = steps; float = fraction of epoch.
+- `working_dir`, `input_file`, `input_directory`, `checkpoint` — the externally-facing paths. Set these from the user's values.
+- `batch_column_name` / `counts_column_name` — **optional**, only used by the batch-integration evaluation callback (see `bmfm_targets/training/callbacks.py`). Never add these unprompted. When running `predict` against a dataset that has batch structure the user cares about, offer the callback explicitly: "your data looks like it has batches — want me to add batch-integration metrics? That needs a batch column (e.g. `batch`, `donor_id`) and a total-counts column (usually added automatically by scanpy QC)". Only emit these keys if the user opts in.
+- `trainer.pooling_method` — how the sequence is pooled into a vector for downstream heads (embeddings, classification). Signature: `str | int | list[int | str]`. Accepted values:
+  - `"first_token"` (default, always valid) — use the hidden state at position 0. Correct choice for any MLM-only checkpoint (its pooler is untrained).
+  - `"pooling_layer"` — use the transformer's `[CLS] → Linear → tanh` pooler. Only valid when the pooler was trained: sequence-classification / multitask checkpoints. Will silently produce garbage on a pure MLM checkpoint.
+  - `"mean_pooling"` — mean over token positions (ignoring padding).
+  - integer (e.g. `1`) — use hidden state at a specific CLS index; matches `decode_from` on a `LabelColumnInfo`. Useful for the v2 47m WCED checkpoint which has 5 CLS tokens.
+  - list of ints / strs (e.g. `[1, 2]`) — concatenate hidden states at several positions. Pattern used in the v2 recipes to combine S+T CLS tokens into one embedding.
+  For `predict` against an RDA checkpoint, `first_token` or `0` is the usual choice. For finetune against a multi-CLS v2 checkpoint, pick the `decode_from` of whichever pretrained head is closest to your task; if unsure, `first_token` is always a safe fallback.
+
+## Multi-task Hydra runs (sequential)
+
+The `scbert_main.py` entry supports `task` being a **list** of task configs; the loop runs each in sequence, reusing the trainer. Useful for "train, then test" or "finetune, then predict" pipelines. See `run/prediction_train_and_test_config.yaml` and `run/transform_and_prediction_train_config.yaml` for examples. This skill rarely needs to generate these from scratch — if the user wants that pattern, start from one of those templates.

--- a/.claude/skills/bmfm-targets-run/scripts/dry_run.sh
+++ b/.claude/skills/bmfm-targets-run/scripts/dry_run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Level-1 validator: renders the fully-resolved Hydra config without running
+# training. This catches most config authoring errors (missing fields, bad
+# interpolations, wrong override operators) in under a second.
+#
+# Pass the exact same args you'd give `bmfm-targets-run`, e.g.:
+#
+#   bash scripts/dry_run.sh -cd run -cn finetune \
+#       input_file=/tmp/data.h5ad \
+#       working_dir=/tmp/run \
+#       checkpoint=ibm-research/biomed.rna.bert.110m.wced.multitask.v1 \
+#       label_column_name=celltype \
+#       split_column_name=split_random
+#
+# Exits nonzero if resolution fails (errors go to stderr as normal).
+#
+# For a Level-2 smoke test (actually run a handful of steps on CPU), use:
+#
+#   bmfm-targets-run <your args> \
+#     task.max_epochs=1 ++task.max_steps=5 \
+#     data_module.num_workers=0 \
+#     task.accelerator=cpu task.precision=32
+
+set -euo pipefail
+
+if ! command -v bmfm-targets-run >/dev/null 2>&1; then
+  echo "ERROR: bmfm-targets-run not on PATH. Activate the venv first." >&2
+  exit 127
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <all the args you'd pass to bmfm-targets-run>" >&2
+  echo "       e.g. $0 -cd run -cn predict input_file=... checkpoint=..." >&2
+  exit 2
+fi
+
+exec bmfm-targets-run "$@" --cfg job --resolve

--- a/bmfm_targets/config/main_config.py
+++ b/bmfm_targets/config/main_config.py
@@ -95,6 +95,7 @@ class SCBertMainConfig:
 
     def complete_config(self):
         self._merge_configs_from_checkpoint()
+        self._apply_device_constraints()
         tokenizer = self._load_tokenizer_from_cfg()
 
         if isinstance(self.data_module, functools.partial):
@@ -349,7 +350,6 @@ class SCBertMainConfig:
         if self.model is None and ckpt_model_config is not None:
             self.model = ckpt_model_config
             self.model.checkpoint = checkpoint
-            self._apply_device_constraints()
 
         # Merge trainer config
         if ckpt_trainer_config and self.trainer:
@@ -467,23 +467,15 @@ class SCBertMainConfig:
         return load_tokenizer(identifier, self.tokenizer.prepend_tokens)
 
     def _apply_device_constraints(self) -> None:
-        """
-        Override device-specific model config flags when not on a CUDA-capable device.
-
-        GPU-first: auto/gpu/cuda keep checkpoint settings as-is.
-        CPU/MPS (and anything unrecognised) fall back to attention='torch' (SDPA),
-        since flex_attention only supports CUDA.
-        """
+        """Override model config flags that require CUDA when CUDA is not available."""
         if self.model is None:
             return
-        accelerator = getattr(self.task, "accelerator", "auto")
-        if accelerator in ("gpu", "cuda", "auto"):
-            return
-        if getattr(self.model, "attention", None) == "flex":
+        if (
+            getattr(self.model, "attention", None) == "flex"
+            and not torch.cuda.is_available()
+        ):
             logger.warning(
-                "attention='flex' is not supported on accelerator='%s'. "
-                "Falling back to attention='torch' (SDPA).",
-                accelerator,
+                "attention='flex' requires CUDA; falling back to attention='torch' (SDPA)."
             )
             self.model.attention = "torch"
 

--- a/run/predict.yaml
+++ b/run/predict.yaml
@@ -1,6 +1,7 @@
 defaults:
   - data_module: base_seq_cls
   - task: predict
+  - trainer: default
   - _self_
 
 seed:


### PR DESCRIPTION
This PR adds a Claude skill to the repo which handles many of the workflows that a user may be interested in performing. It works fairly well, enabling the launch of standard usages of the package, working with the published checkpoints, preparing the data correctly without requiring too much of the user. It has been tested within claude cli but it should work with other agents also.