### PR TITLE
pin `rdata!=1.1.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "numpy",
   "scipy",
   "torch>=2.0.0",
-  "rdata",
+  "rdata!=1.1.0", #1.1.0 enables code execution from docstrings, flagged as a security vulnerability
   "pytorch-lightning>=2.0.0",
   "transformers>=4.54.0,<5.0.0",
   "omegaconf",


### PR DESCRIPTION
following reports on 1.1.0 we will avoid this version

https://socket.dev/pypi/package/rdata/overview/1.1.0