### PR TITLE
Support per-split processed_data_source in DataModule

### DIFF
--- a/.github/workflows/dna_test-cli.yml
+++ b/.github/workflows/dna_test-cli.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install cURL Headers (for hic-straw install/build)
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
     - name: Install package
       run: uv pip install -q .
     - name: Print environment

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install cURL Headers (for hic-straw install/build)
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
     - name: Install python build/environment requirements
       run: uv pip install -q pip wheel pytest-cov nbqa pylint
     - name: Install package

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install cURL Headers (for hic-straw install/build)
       run: |
         sudo apt-get update
-        sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
     - name: Install package
       run: uv pip install -q .
     - name: Print environment

--- a/bmfm_targets/tests/test_base_dataset.py
+++ b/bmfm_targets/tests/test_base_dataset.py
@@ -394,3 +394,44 @@ def test_perturbation_dataset_respects_expose_zeros(
             / mfi.seq_length
         )
         assert zero_ratio == 0
+
+
+def _tiny_split_adata(n_obs: int, tag: str):
+    """A minimal AnnData standing in for a pre-split file (all cells one split)."""
+    X = rand(n_obs, 6, density=0.5, format="csr")
+    adata = sc.AnnData(X)
+    adata.obs_names = [f"{tag}{i}" for i in range(n_obs)]
+    adata.var_names = [f"gene{j}" for j in range(6)]
+    adata.obs["origin"] = tag
+    return adata
+
+
+def test_data_module_per_split_processed_data_source(
+    pl_data_module_zheng68k_seq_cls, tmp_path
+):
+    """A per-split ``processed_data_source`` mapping loads a different file per split."""
+    train_path = tmp_path / "train.h5ad"
+    dev_path = tmp_path / "val.h5ad"
+    _tiny_split_adata(n_obs=8, tag="train").write_h5ad(train_path)
+    _tiny_split_adata(n_obs=3, tag="dev").write_h5ad(dev_path)
+
+    data_module = DataModule(
+        tokenizer=pl_data_module_zheng68k_seq_cls.tokenizer,
+        fields=pl_data_module_zheng68k_seq_cls.fields,
+        dataset_kwargs={
+            "processed_data_source": {
+                "train": str(train_path),
+                "dev": str(dev_path),
+            }
+        },
+        transform_datasets=False,
+        limit_genes=None,
+        batch_size=1,
+        max_length=32,
+    )
+    data_module.setup("fit")
+
+    assert data_module.train_dataset.processed_data.n_obs == 8
+    assert data_module.dev_dataset.processed_data.n_obs == 3
+    assert set(data_module.train_dataset.metadata["origin"]) == {"train"}
+    assert set(data_module.dev_dataset.metadata["origin"]) == {"dev"}

--- a/bmfm_targets/training/data_module.py
+++ b/bmfm_targets/training/data_module.py
@@ -526,7 +526,7 @@ class DataModule(pl.LightningDataModule):
         exactly one split (so no further filtering is applied).
         """
         kwargs = {**self.dataset_kwargs}
-        source = kwargs["processed_data_source"]
+        source = kwargs.get("processed_data_source")
         dataset_split = split
         if split is not None and isinstance(source, Mapping):
             kwargs["processed_data_source"] = source[split]

--- a/bmfm_targets/training/data_module.py
+++ b/bmfm_targets/training/data_module.py
@@ -504,38 +504,38 @@ class DataModule(pl.LightningDataModule):
         self.dataset_kwargs = self._prepare_dataset_kwargs()
 
         if stage == "fit" or stage is None:
-            self.train_dataset = self.DATASET_FACTORY(
-                **self.dataset_kwargs,
-                split="train",
-                limit_samples=self._dataset_sample_limit("train"),
-            )
-            self.dev_dataset = self.DATASET_FACTORY(
-                **self.dataset_kwargs,
-                split="dev",
-                limit_samples=self._dataset_sample_limit("dev"),
-            )
+            self.train_dataset = self._init_dataset("train")
+            self.dev_dataset = self._init_dataset("dev")
         if stage == "validate" or stage is None:
-            self.dev_dataset = self.DATASET_FACTORY(
-                **self.dataset_kwargs,
-                split="dev",
-                limit_samples=self._dataset_sample_limit("dev"),
-            )
+            self.dev_dataset = self._init_dataset("dev")
         if stage == "test" or stage is None:
-            self.test_dataset = self.DATASET_FACTORY(
-                **self.dataset_kwargs,
-                split="test",
-                limit_samples=self._dataset_sample_limit("test"),
-            )
-
+            self.test_dataset = self._init_dataset("test")
         if stage == "predict" or stage is None:
-            self.predict_dataset = self.DATASET_FACTORY(
-                **self.dataset_kwargs,
-                split=None,
-                limit_samples=self._dataset_sample_limit("predict"),
-            )
+            self.predict_dataset = self._init_dataset(None)
 
         if any(field.vocab_update_strategy == "dynamic" for field in self.fields):
             self.update_tokenizer()
+
+    def _init_dataset(self, split: str | None):
+        """
+        Construct the dataset for one split.
+
+        ``processed_data_source`` is either a single source (path/AnnData) shared
+        by all splits and filtered by a split column, or a per-split mapping such
+        as ``{"train": train.h5ad, "dev": val.h5ad}`` where each file already holds
+        exactly one split (so no further filtering is applied).
+        """
+        kwargs = {**self.dataset_kwargs}
+        source = kwargs["processed_data_source"]
+        dataset_split = split
+        if split is not None and isinstance(source, Mapping):
+            kwargs["processed_data_source"] = source[split]
+            dataset_split = None
+        return self.DATASET_FACTORY(
+            **kwargs,
+            split=dataset_split,
+            limit_samples=self._dataset_sample_limit(split or "predict"),
+        )
 
     def _prepare_dataset_kwargs(self):
         """
@@ -574,6 +574,11 @@ class DataModule(pl.LightningDataModule):
 
     def load_processed_data(self):
         if self.dataset_kwargs and "processed_data_source" in self.dataset_kwargs:
+            # case: per-split sources, e.g. {"train": train.h5ad, "dev": val.h5ad}.
+            # Left unresolved here; setup() reads the file for each split (see
+            # `_init_dataset`), so we don't load every split into memory eagerly.
+            if isinstance(self.dataset_kwargs["processed_data_source"], Mapping):
+                return self.dataset_kwargs["processed_data_source"]
             # case: user provides anndata object already prepared in dataset_kwargs
             if isinstance(self.dataset_kwargs["processed_data_source"], AnnData):
                 return self.dataset_kwargs["processed_data_source"]

--- a/bmfm_targets/training/data_module.py
+++ b/bmfm_targets/training/data_module.py
@@ -553,7 +553,11 @@ class DataModule(pl.LightningDataModule):
         if self.dataset_kwargs:
             final_dataset_kwargs = {**self.dataset_kwargs}
         final_dataset_kwargs["stratifying_label"] = self.stratifying_label
-        final_dataset_kwargs["processed_data_source"] = self.load_processed_data()
+        # A single shared source is loaded once here so it isn't re-read per split.
+        # A per-split mapping ({"train": ..., "dev": ...}) is left as-is; each split's
+        # file is read on demand in `_init_dataset`.
+        if not isinstance(final_dataset_kwargs.get("processed_data_source"), Mapping):
+            final_dataset_kwargs["processed_data_source"] = self.load_processed_data()
         final_dataset_kwargs["limit_samples_shuffle"] = self.shuffle
         if self.limit_genes is not None:
             final_dataset_kwargs["limit_genes"] = self._get_limited_gene_list(
@@ -574,11 +578,6 @@ class DataModule(pl.LightningDataModule):
 
     def load_processed_data(self):
         if self.dataset_kwargs and "processed_data_source" in self.dataset_kwargs:
-            # case: per-split sources, e.g. {"train": train.h5ad, "dev": val.h5ad}.
-            # Left unresolved here; setup() reads the file for each split (see
-            # `_init_dataset`), so we don't load every split into memory eagerly.
-            if isinstance(self.dataset_kwargs["processed_data_source"], Mapping):
-                return self.dataset_kwargs["processed_data_source"]
             # case: user provides anndata object already prepared in dataset_kwargs
             if isinstance(self.dataset_kwargs["processed_data_source"], AnnData):
                 return self.dataset_kwargs["processed_data_source"]


### PR DESCRIPTION
Allow dataset_kwargs.processed_data_source to be a per-split mapping, e.g. {"train": train.h5ad, "dev": val.h5ad}, so already-split files can be loaded directly instead of filtering one file by a split column.

Collapses the five near-identical dataset-construction blocks in setup() into a single _init_dataset(split) helper that resolves the per-split source (passing split=None so the file is used whole) or falls back to the existing single-source behavior.